### PR TITLE
feat: add QStringList, QByteArray and QUrl arguments

### DIFF
--- a/cpp/module_proxy.cpp
+++ b/cpp/module_proxy.cpp
@@ -94,6 +94,16 @@ namespace {
                     );
                     break;
                 }
+                  case QMetaType::QUrl: {
+                    auto value = new QUrl{arg.toUrl()};
+                    scopedArgs.emplace_back(
+                        Q_ARG(QUrl, *value),
+                        [](const void* data) {
+                            delete static_cast<const QUrl*>(data);
+                        }
+                    );
+                    break;
+                }
                 case QMetaType::QString:
                 default: {
                     auto value = new QString{arg.toString()};


### PR DESCRIPTION
Currently we can pass only QString or int arguments to functions. This PR adds `QStringList`, `QByteArray` and `QUrl` type.