### PR TITLE
fix: redact sensitive data from debug logs

### DIFF
--- a/cpp/logos_api_client.cpp
+++ b/cpp/logos_api_client.cpp
@@ -35,10 +35,10 @@ bool LogosAPIClient::reconnect()
     return m_consumer->reconnect();
 }
 
-QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName, 
+QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName,
                                    const QVariantList& args, Timeout timeout)
 {
-    qDebug() << "LogosAPIClient: invoking remote method" << objectName << methodName << args;
+    qDebug() << "LogosAPIClient: invoking remote method" << objectName << methodName << "args_count:" << args.size();
 
     // Get the token for the module
     QString token = getToken(objectName);
@@ -67,33 +67,33 @@ QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QSt
     return m_consumer->invokeRemoteMethod(token, objectName, methodName, args, timeout);
 }
 
-QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName, 
+QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName,
                                    const QVariant& arg, Timeout timeout)
 {
     return invokeRemoteMethod(objectName, methodName, QVariantList() << arg, timeout);
 }
 
-QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName, 
+QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName,
                                    const QVariant& arg1, const QVariant& arg2, Timeout timeout)
 {
     return invokeRemoteMethod(objectName, methodName, QVariantList() << arg1 << arg2, timeout);
 }
 
-QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName, 
+QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName,
                                    const QVariant& arg1, const QVariant& arg2, const QVariant& arg3, Timeout timeout)
 {
     return invokeRemoteMethod(objectName, methodName, QVariantList() << arg1 << arg2 << arg3, timeout);
 }
 
-QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName, 
-                                   const QVariant& arg1, const QVariant& arg2, const QVariant& arg3, 
+QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName,
+                                   const QVariant& arg1, const QVariant& arg2, const QVariant& arg3,
                                    const QVariant& arg4, Timeout timeout)
 {
     return invokeRemoteMethod(objectName, methodName, QVariantList() << arg1 << arg2 << arg3 << arg4, timeout);
 }
 
-QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName, 
-                                   const QVariant& arg1, const QVariant& arg2, const QVariant& arg3, 
+QVariant LogosAPIClient::invokeRemoteMethod(const QString& objectName, const QString& methodName,
+                                   const QVariant& arg1, const QVariant& arg2, const QVariant& arg3,
                                    const QVariant& arg4, const QVariant& arg5, Timeout timeout)
 {
     return invokeRemoteMethod(objectName, methodName, QVariantList() << arg1 << arg2 << arg3 << arg4 << arg5, timeout);
@@ -131,7 +131,7 @@ void LogosAPIClient::onEventResponse(QObject* replica, const QString& eventName,
 
     // emit the eventResponse signal of replica
     QMetaObject::invokeMethod(replica, "eventResponse", Qt::QueuedConnection, Q_ARG(QString, eventName), Q_ARG(QVariantList, data));
-} 
+}
 
 bool LogosAPIClient::informModuleToken(const QString& authToken, const QString& moduleName, const QString& token)
 {
@@ -150,28 +150,19 @@ TokenManager* LogosAPIClient::getTokenManager() const
 
 QString LogosAPIClient::getToken(const QString& module_name)
 {
-    qDebug() << "getoken: -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-";
-    qDebug() << "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-";
-    // if (m_token_manager) {
-        qDebug() << "LogosAPIClient: printing keys";
-        QList<QString> keys = m_token_manager->getTokenKeys();
-        for (const QString& key : keys) {
-           qDebug() << "LogosAPIClient: Token key:" << key << "value:" << m_token_manager->getToken(key);
-        }
+    qDebug() << "LogosAPIClient: getToken for module:" << module_name;
 
+    // if (m_token_manager) {
         QString token = m_token_manager->getToken(module_name);
         if (!token.isEmpty()) {
             qDebug() << "LogosAPIClient: Found token for module:" << module_name;
             return token;
-        } else {
-            qDebug() << "LogosAPIClient: No token found for module:" << module_name;
         }
     // } else {
         // qDebug() << "LogosAPIClient: No token manager found - using default AUTH_TOKEN";
     // }
 
-    qDebug() << "LogosAPIClient: No stored token for module:" << module_name;
-    qDebug() << "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-";
+    qDebug() << "LogosAPIClient: No token found for module:" << module_name;
 
     // TODO: this is breaking here for core_manager
     // return AUTH_TOKEN;

--- a/cpp/logos_api_consumer.cpp
+++ b/cpp/logos_api_consumer.cpp
@@ -150,12 +150,12 @@ bool LogosAPIConsumer::connectToRegistry()
 
 
 
-QVariant LogosAPIConsumer::invokeRemoteMethod(const QString& authToken, const QString& objectName, const QString& methodName, 
+QVariant LogosAPIConsumer::invokeRemoteMethod(const QString& authToken, const QString& objectName, const QString& methodName,
                                    const QVariantList& args, Timeout timeout)
 {
-    qDebug() << "LogosAPIConsumer: Calling invokeRemoteMethod with params:" << authToken << objectName << methodName << args << timeout.ms;
+    qDebug() << "LogosAPIConsumer: Calling invokeRemoteMethod:" << objectName << methodName << "args_count:" << args.size() << "timeout:" << timeout.ms;
 
-    // This method handles both ModuleProxy-wrapped modules (template_module, package_manager) 
+    // This method handles both ModuleProxy-wrapped modules (template_module, package_manager)
     // and direct remote object calls for other modules
     QObject* plugin = requestObject(objectName, timeout);
     if (!plugin) {
@@ -217,7 +217,7 @@ void LogosAPIConsumer::onEvent(QObject* originObject, QObject* destinationObject
     // Check if we already have a connection for this origin object
     if (!m_connections.contains(originObject)) {
         // Create new connection only if it doesn't exist
-        auto connection = QObject::connect(originObject, SIGNAL(eventResponse(QString, QVariantList)), 
+        auto connection = QObject::connect(originObject, SIGNAL(eventResponse(QString, QVariantList)),
                                           this, SLOT(invokeCallback(QString, QVariantList)));
 
         if (connection) {
@@ -256,7 +256,7 @@ void LogosAPIConsumer::onEvent(QObject* originObject, QObject* destinationObject
     qDebug() << "LogosAPIConsumer: Registering event listener for event:" << eventName << "(connecting to destination slot)";
 
     // connect to the eventResponse signal of the destinationObject's slot
-    QObject::connect(originObject, SIGNAL(eventResponse(QString, QVariantList)), 
+    QObject::connect(originObject, SIGNAL(eventResponse(QString, QVariantList)),
                     destinationObject, SLOT(onEventResponse(QString, QVariantList)), Qt::AutoConnection);
 }
 

--- a/cpp/module_proxy.cpp
+++ b/cpp/module_proxy.cpp
@@ -199,7 +199,7 @@ bool ModuleProxy::saveToken(const QString& from_module_name, const QString& toke
 
     qDebug() << "ModuleProxy: Saving token for module:" << from_module_name;
     m_tokens[from_module_name] = token;
-    
+
     qDebug() << "ModuleProxy: Token saved successfully. Total tokens stored:" << m_tokens.size();
     return true;
 }
@@ -252,7 +252,7 @@ QVariant ModuleProxy::callRemoteMethod(const QString& authToken, const QString& 
     // print keys vand values for debug purposes
     QList<QString> keys = tokenManager->getTokenKeys();
     for (const QString& key : keys) {
-       qDebug() << "ModuleProxy: Token key:" << key << "value:" << tokenManager->getToken(key);
+       qDebug() << "ModuleProxy: Token key:" << key;
     }
 
     // check if authToken is valid


### PR DESCRIPTION
Remove logging of method arguments. It may contain private keys, DB passwords, auth tokens, and token values. Log only method names and argument counts for debugging.

- https://github.com/status-im/infra-logos/issues/1