### PR TITLE
add Logos instance id to registry url

### DIFF
--- a/cpp/logos_api_consumer.cpp
+++ b/cpp/logos_api_consumer.cpp
@@ -3,6 +3,7 @@
 #include "logos_api_client.h"
 #include "token_manager.h"
 #include "logos_mode.h"
+#include "logos_instance.h"
 #include "plugin_registry.h"
 #include <QRemoteObjectNode>
 #include <QRemoteObjectReplica>
@@ -11,12 +12,11 @@
 #include <QUrl>
 #include <QMetaObject>
 #include <QTime>
-#include <string>
 
 LogosAPIConsumer::LogosAPIConsumer(const QString& module_to_talk_to, const QString& origin_module, TokenManager* token_manager, QObject *parent)
     : QObject(parent)
     , m_node(nullptr)
-    , m_registryUrl(QString("local:logos_%1").arg(module_to_talk_to))
+    , m_registryUrl(LogosInstance::id(module_to_talk_to))
     , m_connected(false)
     , m_token_manager(token_manager)
 {

--- a/cpp/logos_api_provider.cpp
+++ b/cpp/logos_api_provider.cpp
@@ -2,16 +2,18 @@
 #include "module_proxy.h"
 #include "logos_api.h"
 #include "logos_mode.h"
+#include "logos_instance.h"
 #include "plugin_registry.h"
 #include <QRemoteObjectRegistryHost>
 #include <QDebug>
 #include <QUrl>
 #include <QMetaObject>
+#include <QString>
 
 LogosAPIProvider::LogosAPIProvider(const QString& module_name, QObject *parent)
     : QObject(parent)
     , m_registryHost(nullptr)
-    , m_registryUrl(QString("local:logos_%1").arg(module_name))
+    , m_registryUrl(LogosInstance::id(module_name))
     , m_moduleProxy(nullptr)
 {
 }

--- a/cpp/logos_instance.h
+++ b/cpp/logos_instance.h
@@ -1,0 +1,32 @@
+#ifndef LOGOS_INSTANCE_H
+#define LOGOS_INSTANCE_H
+
+#include <QDebug>
+#include <QString>
+#include <QUuid>
+
+/**
+ * @brief LogosInstance provides a shared identifier for all processes launched
+ * by Logos core
+ *
+ * The root process generates a UUID-based ID and exports it via the
+ * LOGOS_INSTANCE_ID environment variable. Child processes inherit the variable
+ * and return the same ID, so all processes in the application tree share one
+ * ID. Used by both provider and consumer to build matching registry URLs.
+ */
+namespace LogosInstance {
+    inline const QString id() {
+        const QByteArray inherited = qgetenv("LOGOS_INSTANCE_ID");
+        if (!inherited.isEmpty())
+            return QString::fromUtf8(inherited);
+        const QString newId = QUuid::createUuid().toString(QUuid::Id128).left(12);
+        qputenv("LOGOS_INSTANCE_ID", newId.toUtf8());
+        return newId;
+    }
+
+    inline QString id(const QString& moduleName) {
+        return QString("local:logos_%1_%2").arg(moduleName).arg(id());
+    }
+}
+
+#endif // LOGOS_INSTANCE_H

--- a/nix/include.nix
+++ b/nix/include.nix
@@ -27,7 +27,7 @@ pkgs.stdenv.mkDerivation {
     # Install cpp headers and sources
     for file in logos_types.cpp logos_types.h logos_api.cpp logos_api.h logos_api_client.cpp logos_api_client.h \
                 logos_api_consumer.cpp logos_api_consumer.h logos_api_provider.cpp logos_api_provider.h \
-                token_manager.cpp token_manager.h module_proxy.cpp module_proxy.h logos_mode.h; do
+                token_manager.cpp token_manager.h module_proxy.cpp module_proxy.h logos_mode.h logos_instance.h; do
       if [ -f cpp/$file ]; then
         cp cpp/$file $out/include/cpp/
       fi


### PR DESCRIPTION
Allows multiple Logos core instances to run on the same machine by giving appending a unique instance identifier to each registry url.