### PR TITLE
refactor: abstract connection/transport; and clearly separate qt remote obj and qt local into separate implementations

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -26,7 +26,15 @@ set(SDK_SOURCES
     token_manager.cpp
     token_manager.h
     logos_mode.h
+    logos_instance.h
     plugin_registry.h
+    logos_transport.h
+    logos_transport_factory.cpp
+    logos_transport_factory.h
+    implementations/qt_local/local_transport.cpp
+    implementations/qt_local/local_transport.h
+    implementations/qt_remote/remote_transport.cpp
+    implementations/qt_remote/remote_transport.h
 )
 
 # Create the SDK library as STATIC instead of SHARED
@@ -38,6 +46,8 @@ target_link_libraries(logos_sdk PUBLIC Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSIO
 # Include directories
 target_include_directories(logos_sdk PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/implementations/qt_local
+    ${CMAKE_CURRENT_SOURCE_DIR}/implementations/qt_remote
 )
 
 # Set output directories for static library
@@ -62,6 +72,19 @@ install(FILES
     module_proxy.h
     token_manager.h
     logos_mode.h
+    logos_instance.h
     plugin_registry.h
+    logos_transport.h
+    logos_transport_factory.h
     DESTINATION include
-) 
+)
+
+install(FILES
+    implementations/qt_local/local_transport.h
+    DESTINATION include/implementations/qt_local
+)
+
+install(FILES
+    implementations/qt_remote/remote_transport.h
+    DESTINATION include/implementations/qt_remote
+)

--- a/cpp/implementations/qt_local/local_transport.cpp
+++ b/cpp/implementations/qt_local/local_transport.cpp
@@ -1,0 +1,91 @@
+#include "local_transport.h"
+#include "../../plugin_registry.h"
+#include "../../module_proxy.h"
+#include <QDebug>
+
+// --- LocalTransportHost ---
+
+bool LocalTransportHost::publishObject(const QString& name, QObject* object)
+{
+    PluginRegistry::registerPlugin(object, name);
+    qDebug() << "LocalTransportHost: Published object:" << name;
+    return true;
+}
+
+void LocalTransportHost::unpublishObject(const QString& name)
+{
+    if (!name.isEmpty()) {
+        PluginRegistry::unregisterPlugin(name);
+        qDebug() << "LocalTransportHost: Unpublished object:" << name;
+    }
+}
+
+// --- LocalTransportConnection ---
+
+bool LocalTransportConnection::connectToHost()
+{
+    qDebug() << "LocalTransportConnection: Local mode - no connection needed";
+    return true;
+}
+
+bool LocalTransportConnection::isConnected() const
+{
+    return true;
+}
+
+bool LocalTransportConnection::reconnect()
+{
+    return true;
+}
+
+QObject* LocalTransportConnection::requestObject(const QString& objectName, int /*timeoutMs*/)
+{
+    QObject* plugin = PluginRegistry::getPlugin<QObject>(objectName);
+    if (!plugin) {
+        qWarning() << "LocalTransportConnection: Plugin not found in registry:" << objectName;
+        return nullptr;
+    }
+    qDebug() << "LocalTransportConnection: Found plugin:" << objectName;
+    return plugin;
+}
+
+void LocalTransportConnection::releaseObject(QObject* /*object*/)
+{
+    // Local mode: we don't own the object, so nothing to do
+}
+
+QVariant LocalTransportConnection::callRemoteMethod(QObject* object, const QString& authToken,
+                                                     const QString& methodName, const QVariantList& args,
+                                                     int /*timeoutMs*/)
+{
+    if (!object) {
+        qWarning() << "LocalTransportConnection: Cannot call method on null object";
+        return QVariant();
+    }
+
+    ModuleProxy* proxy = qobject_cast<ModuleProxy*>(object);
+    if (!proxy) {
+        qWarning() << "LocalTransportConnection: Object is not a ModuleProxy";
+        return QVariant();
+    }
+
+    return proxy->callRemoteMethod(authToken, methodName, args);
+}
+
+bool LocalTransportConnection::callInformModuleToken(QObject* object, const QString& authToken,
+                                                      const QString& moduleName, const QString& token,
+                                                      int /*timeoutMs*/)
+{
+    if (!object) {
+        qWarning() << "LocalTransportConnection: Cannot call informModuleToken on null object";
+        return false;
+    }
+
+    ModuleProxy* proxy = qobject_cast<ModuleProxy*>(object);
+    if (!proxy) {
+        qWarning() << "LocalTransportConnection: Object is not a ModuleProxy";
+        return false;
+    }
+
+    return proxy->informModuleToken(authToken, moduleName, token);
+}

--- a/cpp/implementations/qt_local/local_transport.h
+++ b/cpp/implementations/qt_local/local_transport.h
@@ -1,0 +1,27 @@
+#ifndef LOCAL_TRANSPORT_H
+#define LOCAL_TRANSPORT_H
+
+#include "../../logos_transport.h"
+
+class LocalTransportHost : public LogosTransportHost {
+public:
+    bool publishObject(const QString& name, QObject* object) override;
+    void unpublishObject(const QString& name) override;
+};
+
+class LocalTransportConnection : public LogosTransportConnection {
+public:
+    bool connectToHost() override;
+    bool isConnected() const override;
+    bool reconnect() override;
+    QObject* requestObject(const QString& objectName, int timeoutMs) override;
+    void releaseObject(QObject* object) override;
+    QVariant callRemoteMethod(QObject* object, const QString& authToken,
+                               const QString& methodName, const QVariantList& args,
+                               int timeoutMs) override;
+    bool callInformModuleToken(QObject* object, const QString& authToken,
+                                const QString& moduleName, const QString& token,
+                                int timeoutMs) override;
+};
+
+#endif // LOCAL_TRANSPORT_H

--- a/cpp/implementations/qt_remote/remote_transport.cpp
+++ b/cpp/implementations/qt_remote/remote_transport.cpp
@@ -1,0 +1,218 @@
+#include "remote_transport.h"
+#include <QRemoteObjectRegistryHost>
+#include <QRemoteObjectNode>
+#include <QRemoteObjectReplica>
+#include <QRemoteObjectPendingCall>
+#include <QDebug>
+#include <QUrl>
+#include <QMetaObject>
+#include <QTime>
+
+// --- RemoteTransportHost ---
+
+RemoteTransportHost::RemoteTransportHost(const QString& registryUrl)
+    : m_registryHost(nullptr)
+    , m_registryUrl(registryUrl)
+{
+}
+
+RemoteTransportHost::~RemoteTransportHost()
+{
+    delete m_registryHost;
+}
+
+bool RemoteTransportHost::publishObject(const QString& name, QObject* object)
+{
+    if (!m_registryHost) {
+        m_registryHost = new QRemoteObjectRegistryHost(QUrl(m_registryUrl));
+        if (!m_registryHost) {
+            qCritical() << "RemoteTransportHost: Failed to create registry host";
+            return false;
+        }
+        qDebug() << "RemoteTransportHost: Created registry host with URL:" << m_registryUrl;
+    }
+
+    bool success = m_registryHost->enableRemoting(object, name);
+    if (success) {
+        qDebug() << "RemoteTransportHost: Published object:" << name;
+    } else {
+        qCritical() << "RemoteTransportHost: Failed to publish object:" << name;
+    }
+    return success;
+}
+
+void RemoteTransportHost::unpublishObject(const QString& /*name*/)
+{
+    // Qt Remote Objects doesn't require explicit unregistration;
+    // the host cleanup handles it on destruction.
+}
+
+// --- RemoteTransportConnection ---
+
+RemoteTransportConnection::RemoteTransportConnection(const QString& registryUrl)
+    : m_node(new QRemoteObjectNode())
+    , m_registryUrl(registryUrl)
+    , m_connected(false)
+{
+}
+
+RemoteTransportConnection::~RemoteTransportConnection()
+{
+    delete m_node;
+}
+
+bool RemoteTransportConnection::connectToHost()
+{
+    return connectToRegistry();
+}
+
+bool RemoteTransportConnection::isConnected() const
+{
+    return m_connected;
+}
+
+bool RemoteTransportConnection::reconnect()
+{
+    qDebug() << "RemoteTransportConnection: Attempting to reconnect to registry:" << m_registryUrl;
+
+    if (m_connected) {
+        delete m_node;
+        m_node = new QRemoteObjectNode();
+        m_connected = false;
+    }
+
+    return connectToRegistry();
+}
+
+bool RemoteTransportConnection::connectToRegistry()
+{
+    if (!m_node) {
+        qWarning() << "RemoteTransportConnection: Remote object node is null";
+        return false;
+    }
+
+    if (m_registryUrl.isEmpty()) {
+        qWarning() << "RemoteTransportConnection: Registry URL is empty";
+        return false;
+    }
+
+    qDebug() << "RemoteTransportConnection: Connecting to registry:" << m_registryUrl
+             << "at" << QTime::currentTime().toString("hh:mm:ss.zzz");
+
+    QUrl url(m_registryUrl);
+    bool success = m_node->connectToNode(url);
+
+    if (success) {
+        m_connected = true;
+        qDebug() << "RemoteTransportConnection: Successfully connected to registry:" << m_registryUrl;
+    } else {
+        m_connected = false;
+        qWarning() << "RemoteTransportConnection: Failed to connect to registry:" << m_registryUrl;
+    }
+    qDebug() << "RemoteTransportConnection: Connected to registry at"
+             << QTime::currentTime().toString("hh:mm:ss.zzz");
+
+    return m_connected;
+}
+
+QObject* RemoteTransportConnection::requestObject(const QString& objectName, int timeoutMs)
+{
+    if (!m_connected) {
+        qWarning() << "RemoteTransportConnection: Not connected. Cannot request object:" << objectName;
+        return nullptr;
+    }
+
+    qDebug() << "RemoteTransportConnection: Requesting object:" << objectName
+             << "at" << QTime::currentTime().toString("hh:mm:ss.zzz");
+
+    QRemoteObjectReplica* replica = m_node->acquireDynamic(objectName);
+    if (!replica) {
+        qWarning() << "RemoteTransportConnection: Failed to acquire replica for:" << objectName;
+        return nullptr;
+    }
+
+    if (!replica->waitForSource(timeoutMs)) {
+        qWarning() << "RemoteTransportConnection: Timeout waiting for replica:" << objectName;
+        delete replica;
+        return nullptr;
+    }
+
+    qDebug() << "RemoteTransportConnection: Acquired replica for:" << objectName
+             << "at" << QTime::currentTime().toString("hh:mm:ss.zzz");
+    return replica;
+}
+
+void RemoteTransportConnection::releaseObject(QObject* object)
+{
+    delete object;
+}
+
+QVariant RemoteTransportConnection::callRemoteMethod(QObject* object, const QString& authToken,
+                                                      const QString& methodName, const QVariantList& args,
+                                                      int timeoutMs)
+{
+    if (!object) {
+        qWarning() << "RemoteTransportConnection: Cannot call method on null object";
+        return QVariant();
+    }
+
+    QRemoteObjectPendingCall pendingCall;
+    bool success = QMetaObject::invokeMethod(
+        object,
+        "callRemoteMethod",
+        Qt::DirectConnection,
+        Q_RETURN_ARG(QRemoteObjectPendingCall, pendingCall),
+        Q_ARG(QString, authToken),
+        Q_ARG(QString, methodName),
+        Q_ARG(QVariantList, args)
+    );
+
+    if (!success) {
+        qWarning() << "RemoteTransportConnection: Failed to invoke callRemoteMethod on replica";
+        return QVariant();
+    }
+
+    pendingCall.waitForFinished(timeoutMs);
+
+    if (!pendingCall.isFinished() || pendingCall.error() != QRemoteObjectPendingCall::NoError) {
+        qWarning() << "RemoteTransportConnection: callRemoteMethod failed or timed out:" << pendingCall.error();
+        return QVariant();
+    }
+
+    return pendingCall.returnValue();
+}
+
+bool RemoteTransportConnection::callInformModuleToken(QObject* object, const QString& authToken,
+                                                       const QString& moduleName, const QString& token,
+                                                       int timeoutMs)
+{
+    if (!object) {
+        qWarning() << "RemoteTransportConnection: Cannot call informModuleToken on null object";
+        return false;
+    }
+
+    QRemoteObjectPendingCall pendingCall;
+    bool success = QMetaObject::invokeMethod(
+        object,
+        "informModuleToken",
+        Qt::DirectConnection,
+        Q_RETURN_ARG(QRemoteObjectPendingCall, pendingCall),
+        Q_ARG(QString, authToken),
+        Q_ARG(QString, moduleName),
+        Q_ARG(QString, token)
+    );
+
+    if (!success) {
+        qWarning() << "RemoteTransportConnection: Failed to invoke informModuleToken on replica";
+        return false;
+    }
+
+    pendingCall.waitForFinished(timeoutMs);
+
+    if (!pendingCall.isFinished() || pendingCall.error() != QRemoteObjectPendingCall::NoError) {
+        qWarning() << "RemoteTransportConnection: informModuleToken failed or timed out:" << pendingCall.error();
+        return false;
+    }
+
+    return pendingCall.returnValue().toBool();
+}

--- a/cpp/implementations/qt_remote/remote_transport.h
+++ b/cpp/implementations/qt_remote/remote_transport.h
@@ -1,0 +1,48 @@
+#ifndef REMOTE_TRANSPORT_H
+#define REMOTE_TRANSPORT_H
+
+#include "../../logos_transport.h"
+#include <QString>
+
+class QRemoteObjectRegistryHost;
+class QRemoteObjectNode;
+
+class RemoteTransportHost : public LogosTransportHost {
+public:
+    explicit RemoteTransportHost(const QString& registryUrl);
+    ~RemoteTransportHost() override;
+
+    bool publishObject(const QString& name, QObject* object) override;
+    void unpublishObject(const QString& name) override;
+
+private:
+    QRemoteObjectRegistryHost* m_registryHost;
+    QString m_registryUrl;
+};
+
+class RemoteTransportConnection : public LogosTransportConnection {
+public:
+    explicit RemoteTransportConnection(const QString& registryUrl);
+    ~RemoteTransportConnection() override;
+
+    bool connectToHost() override;
+    bool isConnected() const override;
+    bool reconnect() override;
+    QObject* requestObject(const QString& objectName, int timeoutMs) override;
+    void releaseObject(QObject* object) override;
+    QVariant callRemoteMethod(QObject* object, const QString& authToken,
+                               const QString& methodName, const QVariantList& args,
+                               int timeoutMs) override;
+    bool callInformModuleToken(QObject* object, const QString& authToken,
+                                const QString& moduleName, const QString& token,
+                                int timeoutMs) override;
+
+private:
+    bool connectToRegistry();
+
+    QRemoteObjectNode* m_node;
+    QString m_registryUrl;
+    bool m_connected;
+};
+
+#endif // REMOTE_TRANSPORT_H

--- a/cpp/logos_api_consumer.cpp
+++ b/cpp/logos_api_consumer.cpp
@@ -4,10 +4,8 @@
 #include "token_manager.h"
 #include "logos_mode.h"
 #include "logos_instance.h"
-#include "plugin_registry.h"
-#include <QRemoteObjectNode>
-#include <QRemoteObjectReplica>
-#include <QRemoteObjectPendingCall>
+#include "logos_transport.h"
+#include "logos_transport_factory.h"
 #include <QDebug>
 #include <QUrl>
 #include <QMetaObject>
@@ -15,30 +13,20 @@
 
 LogosAPIConsumer::LogosAPIConsumer(const QString& module_to_talk_to, const QString& origin_module, TokenManager* token_manager, QObject *parent)
     : QObject(parent)
-    , m_node(nullptr)
     , m_registryUrl(LogosInstance::id(module_to_talk_to))
-    , m_connected(false)
     , m_token_manager(token_manager)
 {
-    if (LogosModeConfig::isLocal()) {
-        qDebug() << "LogosAPIConsumer: Using Local mode - skipping QRemoteObjectNode";
-        m_connected = true;
-    } else {
-        m_node = new QRemoteObjectNode(this);
-        connectToRegistry();
-    }
+    m_transport = LogosTransportFactory::createConnection(m_registryUrl);
+    m_transport->connectToHost();
 }
 
 LogosAPIConsumer::~LogosAPIConsumer()
 {
-    // Clean up event callbacks and connections
     for (auto it = m_connections.begin(); it != m_connections.end(); ++it) {
         QObject::disconnect(it.value());
     }
     m_eventCallbacks.clear();
     m_connections.clear();
-
-    // QRemoteObjectNode will be deleted automatically as it's a child object
 }
 
 QObject* LogosAPIConsumer::requestObject(const QString& objectName, Timeout timeout)
@@ -50,45 +38,21 @@ QObject* LogosAPIConsumer::requestObject(const QString& objectName, Timeout time
         return nullptr;
     }
 
-    if (LogosModeConfig::isLocal()) {
-        QObject* plugin = PluginRegistry::getPlugin<QObject>(objectName);
-        if (!plugin) {
-            qWarning() << "LogosAPIConsumer: Plugin not found in registry:" << objectName;
-            return nullptr;
-        }
-        qDebug() << "LogosAPIConsumer: Successfully found plugin:" << objectName;
-        return plugin;
-    }
-
-    if (!m_connected) {
+    if (!m_transport->isConnected()) {
         qWarning() << "LogosAPIConsumer: Not connected to registry. Cannot request object:" << objectName;
         return nullptr;
     }
 
-    qDebug() << "LogosAPIConsumer: Requesting object:" << objectName;
-
-    // Acquire the dynamic replica
-    QRemoteObjectReplica* replica = m_node->acquireDynamic(objectName);
-    if (!replica) {
-        qWarning() << "LogosAPIConsumer: Failed to acquire replica for object:" << objectName;
-        return nullptr;
+    QObject* object = m_transport->requestObject(objectName, timeout.ms);
+    if (object) {
+        qDebug() << "LogosAPIConsumer: Successfully acquired object:" << objectName;
     }
-
-    // Wait for the replica to be initialized
-    if (!replica->waitForSource(timeout.ms)) {
-        qWarning() << "LogosAPIConsumer: Timeout waiting for object replica to be ready:" << objectName;
-        delete replica;
-        return nullptr;
-    }
-
-    qDebug() << "LogosAPIConsumer: Successfully acquired replica for object:" << objectName;
-    qDebug() << "LogosAPIConsumer: Replica acquired at" << QTime::currentTime().toString("hh:mm:ss.zzz");
-    return replica;
+    return object;
 }
 
 bool LogosAPIConsumer::isConnected() const
 {
-    return m_connected;
+    return m_transport->isConnected();
 }
 
 QString LogosAPIConsumer::registryUrl() const
@@ -98,125 +62,33 @@ QString LogosAPIConsumer::registryUrl() const
 
 bool LogosAPIConsumer::reconnect()
 {
-    if (LogosModeConfig::isLocal()) {
-        m_connected = true;
-        return true;
-    }
-
     qDebug() << "LogosAPIConsumer: Attempting to reconnect to registry:" << m_registryUrl;
-
-    // Disconnect first if already connected
-    if (m_connected) {
-        // Note: QRemoteObjectNode doesn't have a direct disconnect method
-        // We'll create a new node instead
-        m_node->deleteLater();
-        m_node = new QRemoteObjectNode(this);
-        m_connected = false;
-    }
-
-    return connectToRegistry();
+    return m_transport->reconnect();
 }
-
-bool LogosAPIConsumer::connectToRegistry()
-{
-    if (!m_node) {
-        qWarning() << "LogosAPIConsumer: Remote object node is null";
-        return false;
-    }
-
-    if (m_registryUrl.isEmpty()) {
-        qWarning() << "LogosAPIConsumer: Registry URL is empty";
-        return false;
-    }
-
-    qDebug() << "LogosAPIConsumer: Connecting to registry:" << m_registryUrl;
-    qDebug() << "LogosAPIConsumer: Connecting to registry at" << QTime::currentTime().toString("hh:mm:ss.zzz");
-
-    // Connect to the registry node
-    QUrl url(m_registryUrl);
-    bool success = m_node->connectToNode(url);
-
-    if (success) {
-        m_connected = true;
-        qDebug() << "LogosAPIConsumer: Successfully connected to registry:" << m_registryUrl;
-    } else {
-        m_connected = false;
-        qWarning() << "LogosAPIConsumer: Failed to connect to registry:" << m_registryUrl;
-    }
-    qDebug() << "LogosAPIConsumer: Connected to registry at" << QTime::currentTime().toString("hh:mm:ss.zzz");
-
-    return m_connected;
-}
-
-
 
 QVariant LogosAPIConsumer::invokeRemoteMethod(const QString& authToken, const QString& objectName, const QString& methodName,
                                    const QVariantList& args, Timeout timeout)
 {
     qDebug() << "LogosAPIConsumer: Calling invokeRemoteMethod:" << objectName << methodName << "args_count:" << args.size() << "timeout:" << timeout.ms;
 
-    // This method handles both ModuleProxy-wrapped modules (template_module, package_manager)
-    // and direct remote object calls for other modules
-    QObject* plugin = requestObject(objectName, timeout);
+    QObject* plugin = m_transport->requestObject(objectName, timeout.ms);
     if (!plugin) {
         qWarning() << "LogosAPIConsumer: Failed to acquire plugin/replica for object:" << objectName;
         return QVariant();
     }
 
-    ModuleProxy* moduleProxy = qobject_cast<ModuleProxy*>(plugin);
-    if (moduleProxy) {
-        QVariant result = moduleProxy->callRemoteMethod(authToken, methodName, args);
-        if (!LogosModeConfig::isLocal()) {
-            delete plugin;
-        }
-        return result;
-    }
-
-    if (LogosModeConfig::isLocal()) {
-        qWarning() << "LogosAPIConsumer: Local mode requires ModuleProxy-wrapped objects";
-        return QVariant();
-    }
-
-    // Remote mode: callRemoteMethod returns QRemoteObjectPendingCall, not QVariant
-    QRemoteObjectPendingCall pendingCall;
-    bool success = QMetaObject::invokeMethod(
-        plugin,
-        "callRemoteMethod",
-        Qt::DirectConnection,
-        Q_RETURN_ARG(QRemoteObjectPendingCall, pendingCall),
-        Q_ARG(QString, authToken),
-        Q_ARG(QString, methodName),
-        Q_ARG(QVariantList, args)
-    );
-
-    if (!success) {
-        qWarning() << "LogosAPIConsumer: Failed to invoke callRemoteMethod on replica for object:" << objectName;
-        delete plugin;
-        return QVariant();
-    }
-
-    // Wait for the result
-    pendingCall.waitForFinished(timeout.ms);
-    delete plugin;
-
-    if (!pendingCall.isFinished() || pendingCall.error() != QRemoteObjectPendingCall::NoError) {
-        qWarning() << "LogosAPIConsumer: Remote callRemoteMethod failed or timed out:" << pendingCall.error();
-        return QVariant();
-    }
-
-    return pendingCall.returnValue();
+    QVariant result = m_transport->callRemoteMethod(plugin, authToken, methodName, args, timeout.ms);
+    m_transport->releaseObject(plugin);
+    return result;
 }
 
 void LogosAPIConsumer::onEvent(QObject* originObject, QObject* destinationObject, const QString& eventName, std::function<void(const QString&, const QVariantList&)> callback)
 {
     qDebug() << "LogosAPIConsumer: Registering event listener for event:" << eventName;
 
-    // Store the callback for this event name
     m_eventCallbacks[eventName].append(callback);
 
-    // Check if we already have a connection for this origin object
     if (!m_connections.contains(originObject)) {
-        // Create new connection only if it doesn't exist
         auto connection = QObject::connect(originObject, SIGNAL(eventResponse(QString, QVariantList)),
                                           this, SLOT(invokeCallback(QString, QVariantList)));
 
@@ -235,11 +107,6 @@ void LogosAPIConsumer::onEvent(QObject* originObject, QObject* destinationObject
 
 void LogosAPIConsumer::invokeCallback(const QString& eventName, const QVariantList& data)
 {
-    // qDebug() << "LogosAPIConsumer: invokeCallback called for event:" << eventName;
-
-    // Call all registered callbacks
-    // Note: This will call all callbacks for any event. In a more sophisticated implementation,
-    // you might want to store event names with callbacks to filter them.
     for (const auto& callback : m_eventCallbacks[eventName]) {
         try {
             callback(eventName, data);
@@ -247,15 +114,12 @@ void LogosAPIConsumer::invokeCallback(const QString& eventName, const QVariantLi
             qWarning() << "LogosAPIConsumer: Exception in callback for event:" << eventName;
         }
     }
-
-    // qDebug() << "LogosAPIConsumer: Called" << m_eventCallbacks[eventName].size() << "callbacks for event:" << eventName;
 }
 
 void LogosAPIConsumer::onEvent(QObject* originObject, QObject* destinationObject, const QString& eventName)
 {
     qDebug() << "LogosAPIConsumer: Registering event listener for event:" << eventName << "(connecting to destination slot)";
 
-    // connect to the eventResponse signal of the destinationObject's slot
     QObject::connect(originObject, SIGNAL(eventResponse(QString, QVariantList)),
                     destinationObject, SLOT(onEventResponse(QString, QVariantList)), Qt::AutoConnection);
 }
@@ -264,109 +128,30 @@ bool LogosAPIConsumer::informModuleToken(const QString& authToken, const QString
 {
     qDebug() << "LogosAPIConsumer: Informing module token for module:" << moduleName << "with token:" << token;
 
-    QObject* plugin = requestObject("capability_module", Timeout(20000));
+    QObject* plugin = m_transport->requestObject("capability_module", 20000);
     if (!plugin) {
         qWarning() << "LogosAPIConsumer: Failed to acquire plugin/replica for object: capability_module";
         return false;
     }
 
-    ModuleProxy* moduleProxy = qobject_cast<ModuleProxy*>(plugin);
-    if (moduleProxy) {
-        bool result = moduleProxy->informModuleToken(authToken, moduleName, token);
-        qDebug() << "LogosAPIConsumer: informModuleToken completed with result:" << result;
-        if (!LogosModeConfig::isLocal()) {
-            delete plugin;
-        }
-        return result;
-    }
-
-    if (LogosModeConfig::isLocal()) {
-        qWarning() << "LogosAPIConsumer: Local mode requires ModuleProxy-wrapped objects";
-        return false;
-    }
-
-    QRemoteObjectPendingCall pendingCall;
-    bool success = QMetaObject::invokeMethod(
-        plugin,
-        "informModuleToken",
-        Qt::DirectConnection,
-        Q_RETURN_ARG(QRemoteObjectPendingCall, pendingCall),
-        Q_ARG(QString, authToken),
-        Q_ARG(QString, moduleName),
-        Q_ARG(QString, token)
-    );
-
-    if (!success) {
-        qWarning() << "LogosAPIConsumer: Failed to invoke informModuleToken on replica";
-        delete plugin;
-        return false;
-    }
-
-    pendingCall.waitForFinished(20000);
-    delete plugin;
-
-    if (!pendingCall.isFinished() || pendingCall.error() != QRemoteObjectPendingCall::NoError) {
-        qWarning() << "LogosAPIConsumer: Remote informModuleToken failed or timed out:" << pendingCall.error();
-        return false;
-    }
-
-    QVariant result = pendingCall.returnValue();
+    bool result = m_transport->callInformModuleToken(plugin, authToken, moduleName, token, 20000);
     qDebug() << "LogosAPIConsumer: informModuleToken completed with result:" << result;
-
-    return result.toBool();
+    m_transport->releaseObject(plugin);
+    return result;
 }
 
 bool LogosAPIConsumer::informModuleToken_module(const QString& authToken, const QString& originModule, const QString& moduleName, const QString& token)
 {
     qDebug() << "LogosAPIConsumer: Informing module token for module:" << moduleName << "with token:" << token;
 
-    QObject* plugin = requestObject(originModule, Timeout(20000));
+    QObject* plugin = m_transport->requestObject(originModule, 20000);
     if (!plugin) {
         qWarning() << "LogosAPIConsumer: Failed to acquire plugin/replica for object:" << originModule;
         return false;
     }
 
-    ModuleProxy* moduleProxy = qobject_cast<ModuleProxy*>(plugin);
-    if (moduleProxy) {
-        bool result = moduleProxy->informModuleToken(authToken, moduleName, token);
-        qDebug() << "LogosAPIConsumer: informModuleToken completed with result:" << result;
-        if (!LogosModeConfig::isLocal()) {
-            delete plugin;
-        }
-        return result;
-    }
-
-    if (LogosModeConfig::isLocal()) {
-        qWarning() << "LogosAPIConsumer: Local mode requires ModuleProxy-wrapped objects";
-        return false;
-    }
-    QRemoteObjectPendingCall pendingCall;
-    bool success = QMetaObject::invokeMethod(
-        plugin,
-        "informModuleToken",
-        Qt::DirectConnection,
-        Q_RETURN_ARG(QRemoteObjectPendingCall, pendingCall),
-        Q_ARG(QString, authToken),
-        Q_ARG(QString, moduleName),
-        Q_ARG(QString, token)
-    );
-
-    if (!success) {
-        qWarning() << "LogosAPIConsumer: Failed to invoke informModuleToken on replica";
-        delete plugin;
-        return false;
-    }
-
-    pendingCall.waitForFinished(20000);
-    delete plugin;
-
-    if (!pendingCall.isFinished() || pendingCall.error() != QRemoteObjectPendingCall::NoError) {
-        qWarning() << "LogosAPIConsumer: Remote informModuleToken failed or timed out:" << pendingCall.error();
-        return false;
-    }
-
-    QVariant result = pendingCall.returnValue();
+    bool result = m_transport->callInformModuleToken(plugin, authToken, moduleName, token, 20000);
     qDebug() << "LogosAPIConsumer: informModuleToken completed with result:" << result;
-
-    return result.toBool();
+    m_transport->releaseObject(plugin);
+    return result;
 }

--- a/cpp/logos_api_consumer.h
+++ b/cpp/logos_api_consumer.h
@@ -8,20 +8,21 @@
 #include <QHash>
 #include <QMap>
 #include <functional>
+#include <memory>
 
 #include "logos_mode.h"
 
-class QRemoteObjectNode;
+class LogosTransportConnection;
 class TokenManager;
 
 /**
- * @brief LogosAPIConsumer handles connecting to remote objects and invoking their methods
+ * @brief LogosAPIConsumer handles connecting to module objects and invoking their methods
  * 
  * This class is responsible for the consumer/client side functionality:
- * - Connecting to remote object registries
- * - Requesting remote object replicas
- * - Invoking methods on remote objects
- * - Handling events from remote objects
+ * - Connecting to module registries via the transport layer
+ * - Requesting object handles
+ * - Invoking methods on objects
+ * - Handling events from objects
  */
 class LogosAPIConsumer : public QObject
 {
@@ -43,10 +44,10 @@ public:
     ~LogosAPIConsumer();
 
     /**
-     * @brief Request a remote object replica by name
-     * @param objectName The name of the remote object to acquire
-     * @param timeout Timeout to wait for the replica to be ready (default 20000ms)
-     * @return QObject* pointer to the replica, or nullptr if failed
+     * @brief Request an object handle by name
+     * @param objectName The name of the object to acquire
+     * @param timeout Timeout to wait for the object to be ready (default 20000ms)
+     * @return QObject* pointer to the object, or nullptr if failed
      */
     QObject* requestObject(const QString& objectName, Timeout timeout = Timeout());
 
@@ -69,9 +70,9 @@ public:
     bool reconnect();
 
     /**
-     * @brief Invoke a remote method on a remote object
+     * @brief Invoke a method on a module object
      * @param authToken Authentication token for the operation
-     * @param objectName The name of the remote object
+     * @param objectName The name of the object
      * @param methodName The name of the method to call
      * @param args Arguments to pass to the method
      * @param timeout Timeout to wait for the result (default 20000ms)
@@ -118,25 +119,13 @@ public slots:
     bool informModuleToken_module(const QString& authToken, const QString& originModule, const QString& moduleName, const QString& token);
 
 private:
-    QRemoteObjectNode* m_node;
+    std::unique_ptr<LogosTransportConnection> m_transport;
     QString m_registryUrl;
-    bool m_connected;
     QMap<QString, QString> m_tokens;
     TokenManager* m_token_manager;
 
-    // Store callbacks by event name
     QHash<QString, QList<std::function<void(const QString&, const QVariantList&)>>> m_eventCallbacks;
-    
-    // Track existing connections by origin object to avoid duplicates
     QHash<QObject*, QMetaObject::Connection> m_connections;
-
-    /**
-     * @brief Internal method to establish connection to the registry
-     * @return true if connection successful, false otherwise
-     */
-    bool connectToRegistry();
-
-
 };
 
-#endif // LOGOS_API_CONSUMER_H 
+#endif // LOGOS_API_CONSUMER_H

--- a/cpp/logos_api_provider.cpp
+++ b/cpp/logos_api_provider.cpp
@@ -1,10 +1,9 @@
 #include "logos_api_provider.h"
 #include "module_proxy.h"
 #include "logos_api.h"
-#include "logos_mode.h"
 #include "logos_instance.h"
-#include "plugin_registry.h"
-#include <QRemoteObjectRegistryHost>
+#include "logos_transport.h"
+#include "logos_transport_factory.h"
 #include <QDebug>
 #include <QUrl>
 #include <QMetaObject>
@@ -12,19 +11,17 @@
 
 LogosAPIProvider::LogosAPIProvider(const QString& module_name, QObject *parent)
     : QObject(parent)
-    , m_registryHost(nullptr)
     , m_registryUrl(LogosInstance::id(module_name))
     , m_moduleProxy(nullptr)
 {
+    m_transport = LogosTransportFactory::createHost(m_registryUrl);
 }
 
 LogosAPIProvider::~LogosAPIProvider()
 {
-    if (LogosModeConfig::isLocal() && !m_registeredObjectName.isEmpty()) {
-        PluginRegistry::unregisterPlugin(m_registeredObjectName);
+    if (!m_registeredObjectName.isEmpty()) {
+        m_transport->unpublishObject(m_registeredObjectName);
     }
-    // QRemoteObjectRegistryHost will be deleted automatically as it's a child object
-    // ModuleProxy will be deleted automatically as it's a child object
 }
 
 bool LogosAPIProvider::registerObject(const QString& name, QObject* object)
@@ -39,7 +36,6 @@ bool LogosAPIProvider::registerObject(const QString& name, QObject* object)
         return false;
     }
 
-    // Check if a ModuleProxy was already created - only allow one registration
     if (m_moduleProxy) {
         qCritical() << "LogosAPIProvider: Object already registered. Only one registration per provider is allowed";
         return false;
@@ -47,8 +43,6 @@ bool LogosAPIProvider::registerObject(const QString& name, QObject* object)
 
     qDebug() << "LogosAPIProvider: Creating ModuleProxy for" << name << "wrapping the provided object";
 
-    // Before wrapping with ModuleProxy, call initLogos if the method exists
-    // Check if the object has an initLogos method and call it with the parent (LogosAPI instance)
     int methodIndex = object->metaObject()->indexOfMethod("initLogos(LogosAPI*)");
     if (methodIndex != -1) {
         qDebug() << "LogosAPIProvider: Calling initLogos on object before wrapping";
@@ -65,31 +59,13 @@ bool LogosAPIProvider::registerObject(const QString& name, QObject* object)
     }
 
     m_moduleProxy = new ModuleProxy(object, this);
-    object = m_moduleProxy;
 
-    bool success = false;
-
-    if (LogosModeConfig::isLocal()) {
-        PluginRegistry::registerPlugin(object, name);
+    bool success = m_transport->publishObject(name, m_moduleProxy);
+    if (success) {
         m_registeredObjectName = name;
-        success = true;
         qDebug() << "LogosAPIProvider: Successfully registered object with name:" << name;
     } else {
-        if (!m_registryHost) {
-            m_registryHost = new QRemoteObjectRegistryHost(QUrl(m_registryUrl));
-            if (!m_registryHost) {
-                qCritical() << "LogosAPIProvider: Failed to create registry host";
-                return false;
-            }
-            qDebug() << "LogosAPIProvider: Created registry host with URL:" << m_registryUrl;
-        }
-
-        success = m_registryHost->enableRemoting(object, name);
-        if (success) {
-            qDebug() << "LogosAPIProvider: Successfully registered object with name:" << name;
-        } else {
-            qCritical() << "LogosAPIProvider: Failed to register object with name:" << name;
-        }
+        qCritical() << "LogosAPIProvider: Failed to register object with name:" << name;
     }
 
     return success;
@@ -113,7 +89,6 @@ bool LogosAPIProvider::saveToken(const QString& from_module_name, const QString&
 
 void LogosAPIProvider::onEventResponse(QObject* replica, const QString& eventName, const QVariantList& data)
 {
-    // qDebug() << "LogosAPIProvider: Received event:" << eventName << "with data:" << data;
     qDebug() << "LogosAPIProvider: Received event:" << eventName;
 
     if (eventName.isEmpty()) {
@@ -121,13 +96,7 @@ void LogosAPIProvider::onEventResponse(QObject* replica, const QString& eventNam
         return;
     }
 
-    // qDebug() << "LogosAPIProvider: Emitting event:" << eventName << "with data:" << data;
     qDebug() << "LogosAPIProvider: Emitting event:" << eventName;
 
-    // emit the eventResponse signal of replica
     QMetaObject::invokeMethod(replica, "eventResponse", Qt::QueuedConnection, Q_ARG(QString, eventName), Q_ARG(QVariantList, data));
-    // QMetaObject::invokeMethod(replica, "eventResponse_another", Qt::QueuedConnection, Q_ARG(QString, eventName), Q_ARG(QVariantList, data));
-    // TODO: try queued connection instead
-    // QMetaObject::invokeMethod(replica, "eventResponse_another", Qt::DirectConnection, Q_ARG(QString, eventName), Q_ARG(QVariantList, data));
 }
-

--- a/cpp/logos_api_provider.h
+++ b/cpp/logos_api_provider.h
@@ -6,18 +6,17 @@
 #include <QVariant>
 #include <QVariantList>
 #include <QMap>
+#include <memory>
 
-class QRemoteObjectRegistryHost;
+class LogosTransportHost;
 class ModuleProxy;
 
-#include "logos_mode.h"
-
 /**
- * @brief LogosAPIProvider handles registering objects for remote access
+ * @brief LogosAPIProvider handles registering objects for access by consumers
  * 
  * This class is responsible for the provider/server side functionality:
- * - Creating registry hosts
- * - Registering objects for remote access
+ * - Wrapping module objects with ModuleProxy
+ * - Publishing them via the transport layer
  * - Handling event responses
  */
 class LogosAPIProvider : public QObject
@@ -33,15 +32,14 @@ public:
     explicit LogosAPIProvider(const QString& module_name, QObject *parent = nullptr);
     
     /**
-     * @brief Destructor - cleans up registry host
+     * @brief Destructor - unpublishes registered objects
      */
     ~LogosAPIProvider();
 
     /**
-     * @brief Register an object to be available for remote access
+     * @brief Register an object to be available for access by consumers
      * @param name The name to register the object under
      * @param object The object to register
-     * @param authToken Authentication token for the object
      * @return true if registration successful, false otherwise
      */
     bool registerObject(const QString& name, QObject* object);
@@ -70,13 +68,11 @@ public slots:
     void onEventResponse(QObject* replica, const QString& eventName, const QVariantList& data);
 
 private:
-    QRemoteObjectRegistryHost* m_registryHost;
+    std::unique_ptr<LogosTransportHost> m_transport;
     QString m_registryUrl;
     QMap<QString, QString> m_tokens;
     ModuleProxy* m_moduleProxy;
     QString m_registeredObjectName;
-
-
 };
 
-#endif // LOGOS_API_PROVIDER_H 
+#endif // LOGOS_API_PROVIDER_H

--- a/cpp/logos_transport.h
+++ b/cpp/logos_transport.h
@@ -1,0 +1,103 @@
+#ifndef LOGOS_TRANSPORT_H
+#define LOGOS_TRANSPORT_H
+
+#include <QString>
+#include <QVariant>
+#include <QVariantList>
+
+class QObject;
+
+/**
+ * @brief Abstract interface for the provider/server side of module transport.
+ *
+ * Implementations handle how a module object is made available to consumers
+ * (e.g. via in-process registry, Qt Remote Objects, or other mechanisms).
+ */
+class LogosTransportHost {
+public:
+    virtual ~LogosTransportHost() = default;
+
+    /**
+     * @brief Publish an object so consumers can discover and invoke it
+     * @param name The name to publish the object under
+     * @param object The QObject to publish
+     * @return true if publishing succeeded
+     */
+    virtual bool publishObject(const QString& name, QObject* object) = 0;
+
+    /**
+     * @brief Remove a previously published object
+     * @param name The name the object was published under
+     */
+    virtual void unpublishObject(const QString& name) = 0;
+};
+
+/**
+ * @brief Abstract interface for the consumer/client side of module transport.
+ *
+ * Implementations handle how a consumer connects to a host, acquires object
+ * handles, and invokes methods on them.
+ */
+class LogosTransportConnection {
+public:
+    virtual ~LogosTransportConnection() = default;
+
+    /**
+     * @brief Establish connection to the host/registry
+     * @return true if connection succeeded
+     */
+    virtual bool connectToHost() = 0;
+
+    /**
+     * @brief Check if currently connected
+     */
+    virtual bool isConnected() const = 0;
+
+    /**
+     * @brief Tear down and re-establish the connection
+     * @return true if reconnection succeeded
+     */
+    virtual bool reconnect() = 0;
+
+    /**
+     * @brief Acquire a handle to a named object from the host
+     * @param objectName The published name of the object
+     * @param timeoutMs Maximum time to wait for the object to become available
+     * @return QObject* handle, or nullptr on failure. Caller must use releaseObject() when done.
+     */
+    virtual QObject* requestObject(const QString& objectName, int timeoutMs) = 0;
+
+    /**
+     * @brief Release a previously acquired object handle
+     * @param object The handle returned by requestObject()
+     */
+    virtual void releaseObject(QObject* object) = 0;
+
+    /**
+     * @brief Invoke callRemoteMethod on the given object handle
+     * @param object Handle from requestObject()
+     * @param authToken Authentication token
+     * @param methodName Method to call on the underlying module
+     * @param args Arguments for the method
+     * @param timeoutMs Maximum time to wait for the result
+     * @return The method result, or an invalid QVariant on failure
+     */
+    virtual QVariant callRemoteMethod(QObject* object, const QString& authToken,
+                                       const QString& methodName, const QVariantList& args,
+                                       int timeoutMs) = 0;
+
+    /**
+     * @brief Invoke informModuleToken on the given object handle
+     * @param object Handle from requestObject()
+     * @param authToken Authentication token
+     * @param moduleName Target module name
+     * @param token The token to deliver
+     * @param timeoutMs Maximum time to wait for the result
+     * @return true if the token was delivered successfully
+     */
+    virtual bool callInformModuleToken(QObject* object, const QString& authToken,
+                                        const QString& moduleName, const QString& token,
+                                        int timeoutMs) = 0;
+};
+
+#endif // LOGOS_TRANSPORT_H

--- a/cpp/logos_transport_factory.cpp
+++ b/cpp/logos_transport_factory.cpp
@@ -1,0 +1,25 @@
+#include "logos_transport_factory.h"
+#include "logos_transport.h"
+#include "logos_mode.h"
+#include "implementations/qt_local/local_transport.h"
+#include "implementations/qt_remote/remote_transport.h"
+
+namespace LogosTransportFactory {
+
+std::unique_ptr<LogosTransportHost> createHost(const QString& registryUrl)
+{
+    if (LogosModeConfig::isLocal()) {
+        return std::make_unique<LocalTransportHost>();
+    }
+    return std::make_unique<RemoteTransportHost>(registryUrl);
+}
+
+std::unique_ptr<LogosTransportConnection> createConnection(const QString& registryUrl)
+{
+    if (LogosModeConfig::isLocal()) {
+        return std::make_unique<LocalTransportConnection>();
+    }
+    return std::make_unique<RemoteTransportConnection>(registryUrl);
+}
+
+}

--- a/cpp/logos_transport_factory.h
+++ b/cpp/logos_transport_factory.h
@@ -1,0 +1,28 @@
+#ifndef LOGOS_TRANSPORT_FACTORY_H
+#define LOGOS_TRANSPORT_FACTORY_H
+
+#include <memory>
+#include <QString>
+
+class LogosTransportHost;
+class LogosTransportConnection;
+
+namespace LogosTransportFactory {
+
+    /**
+     * @brief Create the appropriate transport host for the current mode
+     * @param registryUrl The URL used by the remote transport (ignored in local mode)
+     * @return Owning pointer to the transport host
+     */
+    std::unique_ptr<LogosTransportHost> createHost(const QString& registryUrl);
+
+    /**
+     * @brief Create the appropriate transport connection for the current mode
+     * @param registryUrl The URL to connect to (ignored in local mode)
+     * @return Owning pointer to the transport connection
+     */
+    std::unique_ptr<LogosTransportConnection> createConnection(const QString& registryUrl);
+
+}
+
+#endif // LOGOS_TRANSPORT_FACTORY_H

--- a/nix/include.nix
+++ b/nix/include.nix
@@ -18,6 +18,8 @@ pkgs.stdenv.mkDerivation {
     # Install headers with proper structure
     mkdir -p $out/include/core
     mkdir -p $out/include/cpp
+    mkdir -p $out/include/cpp/implementations/qt_local
+    mkdir -p $out/include/cpp/implementations/qt_remote
     
     # Install core headers
     if [ -f core/interface.h ]; then
@@ -27,9 +29,25 @@ pkgs.stdenv.mkDerivation {
     # Install cpp headers and sources
     for file in logos_types.cpp logos_types.h logos_api.cpp logos_api.h logos_api_client.cpp logos_api_client.h \
                 logos_api_consumer.cpp logos_api_consumer.h logos_api_provider.cpp logos_api_provider.h \
-                token_manager.cpp token_manager.h module_proxy.cpp module_proxy.h logos_mode.h logos_instance.h; do
+                token_manager.cpp token_manager.h module_proxy.cpp module_proxy.h logos_mode.h \
+                logos_instance.h \
+                logos_transport.h logos_transport_factory.h logos_transport_factory.cpp \
+                plugin_registry.h; do
       if [ -f cpp/$file ]; then
         cp cpp/$file $out/include/cpp/
+      fi
+    done
+    
+    # Install transport implementation headers and sources
+    for file in local_transport.h local_transport.cpp; do
+      if [ -f cpp/implementations/qt_local/$file ]; then
+        cp cpp/implementations/qt_local/$file $out/include/cpp/implementations/qt_local/
+      fi
+    done
+
+    for file in remote_transport.h remote_transport.cpp; do
+      if [ -f cpp/implementations/qt_remote/$file ]; then
+        cp cpp/implementations/qt_remote/$file $out/include/cpp/implementations/qt_remote/
       fi
     done
     
@@ -40,4 +58,3 @@ pkgs.stdenv.mkDerivation {
     runHook postInstall
   '';
 }
-


### PR DESCRIPTION
note: need https://github.com/logos-co/logos-cpp-sdk/pull/20 to go in first, and probably rebase again