### PR TITLE
make async method calls truly async

### DIFF
--- a/cpp/implementations/mock/mock_transport.h
+++ b/cpp/implementations/mock/mock_transport.h
@@ -6,6 +6,7 @@
 #include "mock_store.h"
 #include <QString>
 #include <QList>
+#include <QTimer>
 
 /**
  * @brief LogosObject implementation for mock mode.
@@ -26,6 +27,20 @@ public:
                         int /*timeoutMs*/) override
     {
         return MockStore::instance().recordAndReturn(m_moduleName, methodName, args);
+    }
+
+    void callMethodAsync(const QString& /*authToken*/,
+                         const QString& methodName,
+                         const QVariantList& args,
+                         int /*timeoutMs*/,
+                         AsyncResultCallback callback) override
+    {
+        if (!callback) return;
+        QString mod = m_moduleName;
+        QTimer::singleShot(0, [mod, methodName, args, callback]() {
+            QVariant result = MockStore::instance().recordAndReturn(mod, methodName, args);
+            callback(result);
+        });
     }
 
     bool informModuleToken(const QString& /*authToken*/,

--- a/cpp/implementations/qt_local/local_transport.cpp
+++ b/cpp/implementations/qt_local/local_transport.cpp
@@ -3,6 +3,7 @@
 #include "../../module_proxy.h"
 #include <QDebug>
 #include <QMetaObject>
+#include <QTimer>
 
 // ── LocalLogosObject ─────────────────────────────────────────────────────────
 
@@ -55,6 +56,24 @@ public:
         if (!m_proxy) return QVariant();
         qDebug() << "[LogosObject] LocalLogosObject::callMethod" << methodName << "args:" << args.size();
         return m_proxy->callRemoteMethod(authToken, methodName, args);
+    }
+
+    void callMethodAsync(const QString& authToken,
+                         const QString& methodName,
+                         const QVariantList& args,
+                         int /*timeoutMs*/,
+                         AsyncResultCallback callback) override
+    {
+        if (!callback) return;
+        if (!m_proxy) {
+            QTimer::singleShot(0, [callback]() { callback(QVariant()); });
+            return;
+        }
+        ModuleProxy* proxy = m_proxy;
+        QTimer::singleShot(0, [proxy, authToken, methodName, args, callback]() {
+            QVariant result = proxy->callRemoteMethod(authToken, methodName, args);
+            callback(result);
+        });
     }
 
     bool informModuleToken(const QString& authToken,

--- a/cpp/implementations/qt_remote/remote_transport.cpp
+++ b/cpp/implementations/qt_remote/remote_transport.cpp
@@ -3,11 +3,15 @@
 #include <QRemoteObjectNode>
 #include <QRemoteObjectReplica>
 #include <QRemoteObjectPendingCall>
+#include <QRemoteObjectPendingCallWatcher>
+#include <QPointer>
+#include <QTimer>
 #include <QDebug>
 #include <QUrl>
 #include <QMetaObject>
 #include <QTime>
 #include <QJsonArray>
+#include <memory>
 
 // ── RemoteLogosObject ────────────────────────────────────────────────────────
 
@@ -87,6 +91,66 @@ public:
         }
 
         return pendingCall.returnValue();
+    }
+
+    void callMethodAsync(const QString& authToken,
+                         const QString& methodName,
+                         const QVariantList& args,
+                         int timeoutMs,
+                         AsyncResultCallback callback) override
+    {
+        if (!callback) return;
+        if (!m_replica) {
+            QTimer::singleShot(0, [callback]() { callback(QVariant()); });
+            return;
+        }
+
+        qDebug() << "[LogosObject] RemoteLogosObject::callMethodAsync" << methodName << "args:" << args.size();
+
+        QRemoteObjectPendingCall pendingCall;
+        bool success = QMetaObject::invokeMethod(
+            m_replica,
+            "callRemoteMethod",
+            Qt::DirectConnection,
+            Q_RETURN_ARG(QRemoteObjectPendingCall, pendingCall),
+            Q_ARG(QString, authToken),
+            Q_ARG(QString, methodName),
+            Q_ARG(QVariantList, args)
+        );
+
+        if (!success) {
+            qWarning() << "RemoteLogosObject: Failed to invoke callRemoteMethod on replica (async)";
+            QTimer::singleShot(0, [callback]() { callback(QVariant()); });
+            return;
+        }
+
+        auto handled = std::make_shared<bool>(false);
+        auto* watcher = new QRemoteObjectPendingCallWatcher(pendingCall);
+
+        // Success handler -- delivers result on the consumer's thread
+        QObject::connect(watcher, &QRemoteObjectPendingCallWatcher::finished,
+                         watcher, [callback, handled](QRemoteObjectPendingCallWatcher* w) {
+            if (*handled) { w->deleteLater(); return; }
+            *handled = true;
+            QVariant result;
+            if (w->error() == QRemoteObjectPendingCall::NoError) {
+                result = w->returnValue();
+            } else {
+                qWarning() << "RemoteLogosObject: async callMethod error:" << w->error();
+            }
+            callback(result);
+            w->deleteLater();
+        }, Qt::QueuedConnection);
+
+        // Timeout handler -- fires if the watcher hasn't finished in time
+        QPointer<QRemoteObjectPendingCallWatcher> weakWatcher(watcher);
+        QTimer::singleShot(timeoutMs, [weakWatcher, callback, handled]() {
+            if (*handled) return;
+            *handled = true;
+            qWarning() << "RemoteLogosObject: async callMethod timed out";
+            callback(QVariant());
+            if (!weakWatcher.isNull()) weakWatcher->deleteLater();
+        });
     }
 
     bool informModuleToken(const QString& authToken,

--- a/cpp/implementations/qt_remote/remote_transport.cpp
+++ b/cpp/implementations/qt_remote/remote_transport.cpp
@@ -4,14 +4,12 @@
 #include <QRemoteObjectReplica>
 #include <QRemoteObjectPendingCall>
 #include <QRemoteObjectPendingCallWatcher>
-#include <QPointer>
 #include <QTimer>
 #include <QDebug>
 #include <QUrl>
 #include <QMetaObject>
 #include <QTime>
 #include <QJsonArray>
-#include <memory>
 
 // ── RemoteLogosObject ────────────────────────────────────────────────────────
 
@@ -124,14 +122,17 @@ public:
             return;
         }
 
-        auto handled = std::make_shared<bool>(false);
         auto* watcher = new QRemoteObjectPendingCallWatcher(pendingCall);
+
+        // Timeout timer -- parented to the watcher so it is auto-deleted
+        // when the watcher is destroyed, preventing late timeout callbacks.
+        auto* timer = new QTimer(watcher);
+        timer->setSingleShot(true);
 
         // Success handler -- delivers result on the consumer's thread
         QObject::connect(watcher, &QRemoteObjectPendingCallWatcher::finished,
-                         watcher, [callback, handled](QRemoteObjectPendingCallWatcher* w) {
-            if (*handled) { w->deleteLater(); return; }
-            *handled = true;
+                         watcher, [callback, timer](QRemoteObjectPendingCallWatcher* w) {
+            timer->stop(); // cancel timeout
             QVariant result;
             if (w->error() == QRemoteObjectPendingCall::NoError) {
                 result = w->returnValue();
@@ -142,15 +143,14 @@ public:
             w->deleteLater();
         }, Qt::QueuedConnection);
 
-        // Timeout handler -- fires if the watcher hasn't finished in time
-        QPointer<QRemoteObjectPendingCallWatcher> weakWatcher(watcher);
-        QTimer::singleShot(timeoutMs, [weakWatcher, callback, handled]() {
-            if (*handled) return;
-            *handled = true;
+        // Timeout handler -- stops the watcher and delivers empty result
+        QObject::connect(timer, &QTimer::timeout, watcher, [watcher, callback]() {
             qWarning() << "RemoteLogosObject: async callMethod timed out";
             callback(QVariant());
-            if (!weakWatcher.isNull()) weakWatcher->deleteLater();
+            watcher->deleteLater(); // also destroys the timer (child)
         });
+
+        timer->start(timeoutMs);
     }
 
     bool informModuleToken(const QString& authToken,

--- a/cpp/logos_api_consumer.cpp
+++ b/cpp/logos_api_consumer.cpp
@@ -97,10 +97,12 @@ void LogosAPIConsumer::invokeRemoteMethodAsync(const QString& authToken, const Q
         return;
     }
 
-    qDebug() << "[LogosObject] LogosAPIConsumer: async calling via LogosObject::callMethod" << methodName;
-    QVariant result = plugin->callMethod(authToken, methodName, args, timeout.ms);
-    plugin->release();
-    QTimer::singleShot(0, this, [callback, result]() { callback(result); });
+    qDebug() << "[LogosObject] LogosAPIConsumer: async calling via LogosObject::callMethodAsync" << methodName;
+    plugin->callMethodAsync(authToken, methodName, args, timeout.ms,
+        [plugin, callback](QVariant result) {
+            plugin->release();
+            callback(result);
+        });
 }
 
 void LogosAPIConsumer::onEvent(LogosObject* originObject, const QString& eventName, std::function<void(const QString&, const QVariantList&)> callback)

--- a/cpp/logos_api_consumer.cpp
+++ b/cpp/logos_api_consumer.cpp
@@ -12,6 +12,7 @@
 #include <QMetaObject>
 #include <QTimer>
 #include <QTime>
+#include <QPointer>
 
 LogosAPIConsumer::LogosAPIConsumer(const QString& module_to_talk_to, const QString& origin_module, TokenManager* token_manager, QObject *parent)
     : QObject(parent)
@@ -98,9 +99,15 @@ void LogosAPIConsumer::invokeRemoteMethodAsync(const QString& authToken, const Q
     }
 
     qDebug() << "[LogosObject] LogosAPIConsumer: async calling via LogosObject::callMethodAsync" << methodName;
+    // QPointer guards against use-after-free: if the consumer is destroyed
+    // before the transport callback fires, the callback is silently dropped.
+    // No re-queuing needed -- the transport already delivers on a deferred
+    // event-loop iteration (QTimer / QueuedConnection).
+    QPointer<LogosAPIConsumer> self(this);
     plugin->callMethodAsync(authToken, methodName, args, timeout.ms,
-        [plugin, callback](QVariant result) {
+        [plugin, callback, self](QVariant result) {
             plugin->release();
+            if (!self) return;
             callback(result);
         });
 }

--- a/cpp/logos_object.h
+++ b/cpp/logos_object.h
@@ -33,6 +33,26 @@ public:
                                 const QVariantList& args,
                                 int timeoutMs) = 0;
 
+    using AsyncResultCallback = std::function<void(QVariant)>;
+
+    /**
+     * @brief Invoke a method asynchronously; result is delivered via callback.
+     *
+     * Returns immediately. The callback is always invoked on a subsequent
+     * event-loop iteration, never synchronously inside this call.
+     *
+     * @param authToken Authentication token for the operation
+     * @param methodName Method to call on the underlying module
+     * @param args Arguments for the method
+     * @param timeoutMs Maximum time to wait for the result
+     * @param callback Called with the result (invalid QVariant on failure/timeout)
+     */
+    virtual void callMethodAsync(const QString& authToken,
+                                 const QString& methodName,
+                                 const QVariantList& args,
+                                 int timeoutMs,
+                                 AsyncResultCallback callback) = 0;
+
     /**
      * @brief Deliver a module token to the underlying module.
      * @param authToken Authentication token for the operation

--- a/tests/sdk/CMakeLists.txt
+++ b/tests/sdk/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(sdk_tests
     test_mock_transport.cpp
     test_local_transport_integration.cpp
     test_event_system.cpp
+    test_async_calls.cpp
     test_provider_dispatch.cpp
     fixtures/sample_provider.cpp
     ${GENERATED_DISPATCH}

--- a/tests/sdk/test_async_calls.cpp
+++ b/tests/sdk/test_async_calls.cpp
@@ -1,0 +1,288 @@
+#include <gtest/gtest.h>
+#include <QCoreApplication>
+#include "logos_mock.h"
+#include "logos_api.h"
+#include "logos_api_client.h"
+
+class AsyncCallsTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        m_mock = new LogosMockSetup();
+    }
+    void TearDown() override
+    {
+        delete m_api;
+        delete m_mock;
+    }
+
+    void createApi(const QString& targetModule = "mod")
+    {
+        m_api = new LogosAPI("origin");
+        m_client = m_api->getClient(targetModule);
+    }
+
+    LogosMockSetup* m_mock = nullptr;
+    LogosAPI* m_api = nullptr;
+    LogosAPIClient* m_client = nullptr;
+};
+
+TEST_F(AsyncCallsTest, BasicAsyncCallReturnsCorrectResult)
+{
+    m_mock->when("mod", "getValue").thenReturn(QVariant(42));
+    createApi();
+
+    bool called = false;
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "getValue", QVariantList(),
+        [&](QVariant v) { called = true; received = v; });
+
+    EXPECT_FALSE(called); // callback must not fire synchronously
+    QCoreApplication::processEvents();
+    EXPECT_TRUE(called);
+    EXPECT_EQ(received.toInt(), 42);
+}
+
+TEST_F(AsyncCallsTest, AsyncCallWithStringResult)
+{
+    m_mock->when("mod", "getName").thenReturn(QVariant("hello"));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "getName", QVariantList(),
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_EQ(received.toString(), "hello");
+}
+
+TEST_F(AsyncCallsTest, AsyncCallWithBoolResult)
+{
+    m_mock->when("mod", "isReady").thenReturn(QVariant(true));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "isReady", QVariantList(),
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_TRUE(received.toBool());
+}
+
+TEST_F(AsyncCallsTest, AsyncCallWithDoubleResult)
+{
+    m_mock->when("mod", "getPrice").thenReturn(QVariant(3.14));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "getPrice", QVariantList(),
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_DOUBLE_EQ(received.toDouble(), 3.14);
+}
+
+TEST_F(AsyncCallsTest, AsyncCallWithVariantListResult)
+{
+    QVariantList expected = {1, 2, 3};
+    m_mock->when("mod", "getItems").thenReturn(QVariant(expected));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "getItems", QVariantList(),
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_EQ(received.toList().size(), 3);
+}
+
+TEST_F(AsyncCallsTest, AsyncCallWithVariantMapResult)
+{
+    QVariantMap expected;
+    expected["key"] = "value";
+    expected["count"] = 5;
+    m_mock->when("mod", "getData").thenReturn(QVariant(expected));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "getData", QVariantList(),
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    QVariantMap result = received.toMap();
+    EXPECT_EQ(result["key"].toString(), "value");
+    EXPECT_EQ(result["count"].toInt(), 5);
+}
+
+TEST_F(AsyncCallsTest, AsyncCallForwardsArguments)
+{
+    m_mock->when("mod", "add").thenReturn(QVariant(30));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "add",
+        QVariantList() << 10 << 20,
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_EQ(received.toInt(), 30);
+    EXPECT_TRUE(m_mock->wasCalledWith("mod", "add", QVariantList() << 10 << 20));
+}
+
+TEST_F(AsyncCallsTest, AsyncCallTracksCallCount)
+{
+    m_mock->when("mod", "ping").thenReturn(QVariant("pong"));
+    createApi();
+
+    int callCount = 0;
+    auto cb = [&](QVariant) { callCount++; };
+
+    m_client->invokeRemoteMethodAsync("mod", "ping", QVariantList(), cb);
+    m_client->invokeRemoteMethodAsync("mod", "ping", QVariantList(), cb);
+    m_client->invokeRemoteMethodAsync("mod", "ping", QVariantList(), cb);
+
+    QCoreApplication::processEvents();
+    EXPECT_EQ(callCount, 3);
+    EXPECT_EQ(m_mock->callCount("mod", "ping"), 3);
+}
+
+TEST_F(AsyncCallsTest, AsyncNullCallbackDoesNotCrash)
+{
+    m_mock->when("mod", "fn").thenReturn(QVariant(1));
+    createApi();
+
+    m_client->invokeRemoteMethodAsync("mod", "fn", QVariantList(), nullptr);
+    QCoreApplication::processEvents();
+    // no crash = pass
+}
+
+TEST_F(AsyncCallsTest, AsyncCallNoExpectationReturnsInvalidVariant)
+{
+    createApi("other");
+
+    bool called = false;
+    QVariant received(42); // pre-set to non-default
+    m_client->invokeRemoteMethodAsync("other", "nonexistent", QVariantList(),
+        [&](QVariant v) { called = true; received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_TRUE(called);
+    EXPECT_FALSE(received.isValid());
+}
+
+TEST_F(AsyncCallsTest, MultipleConcurrentAsyncCalls)
+{
+    m_mock->when("mod", "a").thenReturn(QVariant(1));
+    m_mock->when("mod", "b").thenReturn(QVariant(2));
+    m_mock->when("mod", "c").thenReturn(QVariant(3));
+    createApi();
+
+    QVariant ra, rb, rc;
+    m_client->invokeRemoteMethodAsync("mod", "a", QVariantList(), [&](QVariant v) { ra = v; });
+    m_client->invokeRemoteMethodAsync("mod", "b", QVariantList(), [&](QVariant v) { rb = v; });
+    m_client->invokeRemoteMethodAsync("mod", "c", QVariantList(), [&](QVariant v) { rc = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_EQ(ra.toInt(), 1);
+    EXPECT_EQ(rb.toInt(), 2);
+    EXPECT_EQ(rc.toInt(), 3);
+}
+
+TEST_F(AsyncCallsTest, AsyncCallbackIsNeverSynchronous)
+{
+    m_mock->when("mod", "fn").thenReturn(QVariant(99));
+    createApi();
+
+    bool calledDuringInvoke = false;
+    bool calledAfterProcessEvents = false;
+
+    m_client->invokeRemoteMethodAsync("mod", "fn", QVariantList(),
+        [&](QVariant) {
+            calledAfterProcessEvents = true;
+        });
+
+    calledDuringInvoke = calledAfterProcessEvents;
+    EXPECT_FALSE(calledDuringInvoke); // must not fire synchronously
+
+    QCoreApplication::processEvents();
+    EXPECT_TRUE(calledAfterProcessEvents);
+}
+
+TEST_F(AsyncCallsTest, AsyncOneArgOverload)
+{
+    m_mock->when("mod", "fn").thenReturn(QVariant(10));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "fn", QVariant("arg1"),
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_EQ(received.toInt(), 10);
+    QVariantList last = m_mock->lastArgs("mod", "fn");
+    ASSERT_EQ(last.size(), 1);
+    EXPECT_EQ(last[0].toString(), "arg1");
+}
+
+TEST_F(AsyncCallsTest, AsyncTwoArgOverload)
+{
+    m_mock->when("mod", "fn").thenReturn(QVariant(20));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "fn", QVariant(1), QVariant(2),
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_EQ(received.toInt(), 20);
+    QVariantList last = m_mock->lastArgs("mod", "fn");
+    ASSERT_EQ(last.size(), 2);
+}
+
+TEST_F(AsyncCallsTest, AsyncThreeArgOverload)
+{
+    m_mock->when("mod", "fn").thenReturn(QVariant(30));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "fn",
+        QVariant(1), QVariant(2), QVariant(3),
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_EQ(received.toInt(), 30);
+    QVariantList last = m_mock->lastArgs("mod", "fn");
+    ASSERT_EQ(last.size(), 3);
+}
+
+TEST_F(AsyncCallsTest, AsyncFourArgOverload)
+{
+    m_mock->when("mod", "fn").thenReturn(QVariant(40));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "fn",
+        QVariant(1), QVariant(2), QVariant(3), QVariant(4),
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_EQ(received.toInt(), 40);
+    QVariantList last = m_mock->lastArgs("mod", "fn");
+    ASSERT_EQ(last.size(), 4);
+}
+
+TEST_F(AsyncCallsTest, AsyncFiveArgOverload)
+{
+    m_mock->when("mod", "fn").thenReturn(QVariant(50));
+    createApi();
+
+    QVariant received;
+    m_client->invokeRemoteMethodAsync("mod", "fn",
+        QVariant(1), QVariant(2), QVariant(3), QVariant(4), QVariant(5),
+        [&](QVariant v) { received = v; });
+
+    QCoreApplication::processEvents();
+    EXPECT_EQ(received.toInt(), 50);
+    QVariantList last = m_mock->lastArgs("mod", "fn");
+    ASSERT_EQ(last.size(), 5);
+}


### PR DESCRIPTION
We seem to have lost some of the changes from https://github.com/logos-co/logos-cpp-sdk/pull/21 during a refactor.
Even though we were generating the async methods, the implementation of the method call was actually blocking.

This PR makes those calls actually async.