### PR TITLE
fix: skip Qt app wrapping for generator to avoid macOS segfault

### DIFF
--- a/nix/bin.nix
+++ b/nix/bin.nix
@@ -10,6 +10,12 @@ pkgs.stdenv.mkDerivation {
   
   # Skip default configure phase since we do it in buildPhase
   dontUseCmakeConfigure = true;
+
+  # The generator is a build-time CLI tool, not a runtime Qt app — it doesn't
+  # need QT_PLUGIN_PATH or other env vars injected by wrapQtApp. Skipping the
+  # wrap step avoids a segfault in wrapQtAppsNoGuiHook on some macOS versions
+  # where the Darwin binary wrapper tooling crashes (exit code 139).
+  dontWrapQtApps = true;
   
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
The logos-cpp-generator is a build-time CLI tool that uses Qt Remote Objects for code generation. It doesn't need QT_PLUGIN_PATH or other runtime env vars injected by wrapQtAppsNoGuiHook.

On some macOS versions, the wrapQtApp step segfaults (exit code 139) during the fixup phase when the Darwin binary wrapper tooling encounters the generator binary. Setting dontWrapQtApps = true skips this step entirely, fixing the build on affected systems.