### PR TITLE
fix: marshal provider events onto the source thread

### DIFF
--- a/cpp/module_proxy.cpp
+++ b/cpp/module_proxy.cpp
@@ -14,12 +14,15 @@ ModuleProxy::ModuleProxy(LogosProviderObject* provider, QObject* parent)
             // driven from its own thread. Emitting directly from a foreign
             // thread runs QtRO's source serialization there, racing the source
             // socket against a reply being sent from the source thread, which
-            // can silently drop the reply. Marshal the emission onto this
-            // object's thread so events and replies stay serialized on the
-            // single thread QtRO expects to own the source.
+            // can silently drop the reply. AutoConnection keeps same-thread
+            // callers synchronous (the common case) and only queues the
+            // emission when it arrives from another thread, so events and
+            // replies stay serialized on the thread QtRO expects to own the
+            // source. Passing `this` as the context also cancels a queued
+            // emission if this object is destroyed first.
             QMetaObject::invokeMethod(this, [this, eventName, data]() {
                 emit eventResponse(eventName, data);
-            }, Qt::QueuedConnection);
+            }, Qt::AutoConnection);
         });
         qDebug() << "[LogosProviderObject] ModuleProxy: created, wrapping LogosProviderObject"
                  << m_provider->providerName();

--- a/cpp/module_proxy.cpp
+++ b/cpp/module_proxy.cpp
@@ -9,16 +9,14 @@ ModuleProxy::ModuleProxy(LogosProviderObject* provider, QObject* parent)
     if (m_provider) {
         m_provider->setEventListener([this](const QString& eventName, const QVariantList& data) {
             qDebug() << "[LogosProviderObject] ModuleProxy: forwarding event" << eventName << "as Qt signal";
-            // Module events fire on the module's worker/FFI thread, not on this
-            // QObject's (the remoting source's) thread. Emitting eventResponse
-            // directly here runs QtRemoteObjects' source serialization on that
-            // foreign thread, racing the source socket against a method reply
-            // being sent from the source thread — which silently drops the
-            // reply. That is why start(), which emits connectionStateChanged
-            // mid-call, never returns to the caller while createNode (no event)
-            // does. Marshal the emission onto this object's thread so events
-            // and replies are serialized on the single thread QtRemoteObjects
-            // expects to own the source.
+            // Events may be fired from any thread (e.g. a module's worker/FFI
+            // thread), but this object is the QtRemoteObjects source and must be
+            // driven from its own thread. Emitting directly from a foreign
+            // thread runs QtRO's source serialization there, racing the source
+            // socket against a reply being sent from the source thread, which
+            // can silently drop the reply. Marshal the emission onto this
+            // object's thread so events and replies stay serialized on the
+            // single thread QtRO expects to own the source.
             QMetaObject::invokeMethod(this, [this, eventName, data]() {
                 emit eventResponse(eventName, data);
             }, Qt::QueuedConnection);

--- a/cpp/module_proxy.cpp
+++ b/cpp/module_proxy.cpp
@@ -9,7 +9,19 @@ ModuleProxy::ModuleProxy(LogosProviderObject* provider, QObject* parent)
     if (m_provider) {
         m_provider->setEventListener([this](const QString& eventName, const QVariantList& data) {
             qDebug() << "[LogosProviderObject] ModuleProxy: forwarding event" << eventName << "as Qt signal";
-            emit eventResponse(eventName, data);
+            // Module events fire on the module's worker/FFI thread, not on this
+            // QObject's (the remoting source's) thread. Emitting eventResponse
+            // directly here runs QtRemoteObjects' source serialization on that
+            // foreign thread, racing the source socket against a method reply
+            // being sent from the source thread — which silently drops the
+            // reply. That is why start(), which emits connectionStateChanged
+            // mid-call, never returns to the caller while createNode (no event)
+            // does. Marshal the emission onto this object's thread so events
+            // and replies are serialized on the single thread QtRemoteObjects
+            // expects to own the source.
+            QMetaObject::invokeMethod(this, [this, eventName, data]() {
+                emit eventResponse(eventName, data);
+            }, Qt::QueuedConnection);
         });
         qDebug() << "[LogosProviderObject] ModuleProxy: created, wrapping LogosProviderObject"
                  << m_provider->providerName();


### PR DESCRIPTION
Addresses https://github.com/logos-co/logos-delivery-module/issues/44

## Problem

A module method that emits an event **mid-call** never returns to the caller over remoting, while a method that emits nothing returns fine.

Concretely: `delivery_module.start()` emits `connectionStateChanged` as the node connects; the module logs `start completed with success`, but the caller's RPC times out. `createNode()` (no event) works.

## Cause

`ModuleProxy`'s event listener emits `eventResponse` directly on whatever thread the module fired the event from — its worker/FFI thread, not the remoting source's thread. QtRemoteObjects then serializes and sends that event from the foreign thread, racing the source socket against the method reply being sent from the source thread, which silently drops the reply.

## Fix

Marshal the emission onto the `ModuleProxy`'s own thread (`QMetaObject::invokeMethod(this, …, Qt::QueuedConnection)`) so events and replies are serialized on the single thread QtRemoteObjects expects to own the source.

Found by bisecting a downstream consumer hang to the universal-interface migration; verified the asymmetry (event-emitting call hangs, event-free call works) matches this race.