### PR TITLE
feat: dependency interfaces — SDK code generator (bound wrappers)

### DIFF
--- a/cpp-generator/experimental/lidl_gen_client.cpp
+++ b/cpp-generator/experimental/lidl_gen_client.cpp
@@ -103,7 +103,7 @@ static QString asyncDefaultVal(const QString& qt)
 // Header generation
 // ---------------------------------------------------------------------------
 
-QString lidlMakeHeader(const ModuleDecl& module)
+QString lidlMakeHeader(const ModuleDecl& module, BindMode bindMode)
 {
     QString className = lidlToPascalCase(module.name);
     QString h;
@@ -125,7 +125,10 @@ QString lidlMakeHeader(const ModuleDecl& module)
 
     s << "class " << className << " {\n";
     s << "public:\n";
-    s << "    explicit " << className << "(LogosAPI* api);\n\n";
+    if (bindMode == BindMode::Bound)
+        s << "    explicit " << className << "(LogosAPI* api, const QString& moduleName);\n\n";
+    else
+        s << "    explicit " << className << "(LogosAPI* api);\n\n";
 
     s << "    using RawEventCallback = std::function<void(const QString&, const QVariantList&)>;\n";
     s << "    using EventCallback = std::function<void(const QVariantList&)>;\n\n";
@@ -189,7 +192,7 @@ QString lidlMakeHeader(const ModuleDecl& module)
 // Source generation
 // ---------------------------------------------------------------------------
 
-QString lidlMakeSource(const ModuleDecl& module)
+QString lidlMakeSource(const ModuleDecl& module, BindMode bindMode)
 {
     QString className = lidlToPascalCase(module.name);
     QString headerRel = module.name + "_api.h";
@@ -199,8 +202,16 @@ QString lidlMakeSource(const ModuleDecl& module)
     s << "#include \"" << headerRel << "\"\n\n";
     s << "#include <QDebug>\n\n";
 
-    s << className << "::" << className << "(LogosAPI* api) : m_api(api), m_client(api->getClient(\""
-      << module.name << "\")), m_moduleName(QStringLiteral(\"" << module.name << "\")) {}\n\n";
+    // Target expression for every remote call: a baked literal in Static
+    // mode, the runtime m_moduleName member in Bound (interface) mode.
+    const QString targetExpr = (bindMode == BindMode::Bound)
+        ? QStringLiteral("m_moduleName")
+        : (QStringLiteral("\"") + module.name + QStringLiteral("\""));
+    if (bindMode == BindMode::Bound)
+        s << className << "::" << className << "(LogosAPI* api, const QString& moduleName) : m_api(api), m_client(api->getClient(moduleName)), m_moduleName(moduleName) {}\n\n";
+    else
+        s << className << "::" << className << "(LogosAPI* api) : m_api(api), m_client(api->getClient(\""
+          << module.name << "\")), m_moduleName(QStringLiteral(\"" << module.name << "\")) {}\n\n";
 
     s << "LogosObject* " << className << "::ensureReplica() {\n";
     s << "    if (!m_eventReplica) {\n";
@@ -256,12 +267,12 @@ QString lidlMakeSource(const ModuleDecl& module)
         else                s << "    ";
 
         if (nParams <= 5) {
-            s << "m_client->invokeRemoteMethod(\"" << module.name << "\", \"" << md.name << "\"";
+            s << "m_client->invokeRemoteMethod(" << targetExpr << ", \"" << md.name << "\"";
             for (int i = 0; i < nParams; ++i)
                 s << ", " << md.params[i].name;
             s << ");\n";
         } else {
-            s << "m_client->invokeRemoteMethod(\"" << module.name << "\", \"" << md.name << "\", QVariantList{";
+            s << "m_client->invokeRemoteMethod(" << targetExpr << ", \"" << md.name << "\", QVariantList{";
             for (int i = 0; i < nParams; ++i) {
                 s << md.params[i].name;
                 if (i + 1 < nParams) s << ", ";
@@ -281,7 +292,7 @@ QString lidlMakeSource(const ModuleDecl& module)
         if (nParams > 0) s << ", ";
         s << "std::function<void(" << (ret == "void" ? "void" : ret) << ")> callback, Timeout timeout) {\n";
         s << "    if (!callback) return;\n";
-        s << "    m_client->invokeRemoteMethodAsync(\"" << module.name << "\", \"" << md.name << "\", ";
+        s << "    m_client->invokeRemoteMethodAsync(" << targetExpr << ", \"" << md.name << "\", ";
         if (nParams == 0) {
             s << "QVariantList()";
         } else if (nParams == 1) {

--- a/cpp-generator/experimental/lidl_gen_client.h
+++ b/cpp-generator/experimental/lidl_gen_client.h
@@ -2,6 +2,7 @@
 #define LIDL_GEN_CLIENT_H
 
 #include "lidl_ast.h"
+#include "../legacy/generator_lib.h"  // BindMode
 #include <QString>
 #include <QTextStream>
 
@@ -11,11 +12,14 @@ QString lidlTypeToQt(const TypeExpr& te);
 // Convert "my_module" to "MyModule"
 QString lidlToPascalCase(const QString& name);
 
-// Generate the client API header (.h) from a ModuleDecl
-QString lidlMakeHeader(const ModuleDecl& module);
+// Generate the client API header (.h) from a ModuleDecl.
+// `bindMode == Bound` emits an interface wrapper whose ctor takes the
+// target module name at runtime (see BindMode in generator_lib.h); the
+// default Static keeps the historical fixed-module wrapper.
+QString lidlMakeHeader(const ModuleDecl& module, BindMode bindMode = BindMode::Static);
 
 // Generate the client API source (.cpp) from a ModuleDecl
-QString lidlMakeSource(const ModuleDecl& module);
+QString lidlMakeSource(const ModuleDecl& module, BindMode bindMode = BindMode::Static);
 
 // Generate metadata.json content from a ModuleDecl
 QString lidlGenerateMetadataJson(const ModuleDecl& module);

--- a/cpp-generator/legacy/generator_lib.cpp
+++ b/cpp-generator/legacy/generator_lib.cpp
@@ -194,7 +194,7 @@ static bool isQtRefType(const QString& t)
         || t == "QJsonArray" || t == "QVariantList" || t == "QVariantMap";
 }
 
-QString makeHeader(const QString& moduleName, const QString& className, const QJsonArray& methods, ApiStyle apiStyle, const QJsonArray& events)
+QString makeHeader(const QString& moduleName, const QString& className, const QJsonArray& methods, ApiStyle apiStyle, const QJsonArray& events, BindMode bindMode)
 {
     QString h;
     QTextStream s(&h);
@@ -234,7 +234,12 @@ QString makeHeader(const QString& moduleName, const QString& className, const QJ
     }
     s << "class " << className << " {\n";
     s << "public:\n";
-    s << "    explicit " << className << "(LogosAPI* api);\n\n";
+    if (bindMode == BindMode::Bound) {
+        // Interface wrapper: the module to talk to is chosen at runtime.
+        s << "    explicit " << className << "(LogosAPI* api, const QString& moduleName);\n\n";
+    } else {
+        s << "    explicit " << className << "(LogosAPI* api);\n\n";
+    }
     if (apiStyle == ApiStyle::Qt) {
         // Event subscription / trigger surface — Qt-typed.
         s << "    using RawEventCallback = std::function<void(const QString&, const QVariantList&)>;\n";
@@ -366,7 +371,7 @@ QString makeHeader(const QString& moduleName, const QString& className, const QJ
     return h;
 }
 
-QString makeSource(const QString& moduleName, const QString& className, const QString& headerBaseName, const QJsonArray& methods, ApiStyle apiStyle, const QJsonArray& events)
+QString makeSource(const QString& moduleName, const QString& className, const QString& headerBaseName, const QJsonArray& methods, ApiStyle apiStyle, const QJsonArray& events, BindMode bindMode)
 {
     QString c;
     QTextStream s(&c);
@@ -389,7 +394,18 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
         if (!events.isEmpty()) s << "#include \"logos_object.h\"\n";
     }
     s << "\n";
-    s << className << "::" << className << "(LogosAPI* api) : m_api(api), m_client(api->getClient(\"" << moduleName << "\")), m_moduleName(QStringLiteral(\"" << moduleName << "\")) {}\n\n";
+    // The expression every remote call uses to name its target module.
+    // Static: the baked string literal "<moduleName>" (unchanged
+    // behaviour). Bound: the m_moduleName member set from the runtime ctor
+    // arg — so one interface wrapper can talk to any satisfying module.
+    const QString targetExpr = (bindMode == BindMode::Bound)
+        ? QStringLiteral("m_moduleName")
+        : (QStringLiteral("\"") + moduleName + QStringLiteral("\""));
+    if (bindMode == BindMode::Bound) {
+        s << className << "::" << className << "(LogosAPI* api, const QString& moduleName) : m_api(api), m_client(api->getClient(moduleName)), m_moduleName(moduleName) {}\n\n";
+    } else {
+        s << className << "::" << className << "(LogosAPI* api) : m_api(api), m_client(api->getClient(\"" << moduleName << "\")), m_moduleName(QStringLiteral(\"" << moduleName << "\")) {}\n\n";
+    }
 
     // ensureReplica() — generated for std mode too when events are
     // declared. The body is identical to the Qt version; pulled up
@@ -572,15 +588,15 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
         else               s << "    ";
 
         if (params.size() == 0) {
-            s << "m_client->invokeRemoteMethod(\"" << moduleName << "\", \"" << name << "\");\n";
+            s << "m_client->invokeRemoteMethod(" << targetExpr << ", \"" << name << "\");\n";
         } else if (params.size() <= 5) {
-            s << "m_client->invokeRemoteMethod(\"" << moduleName << "\", \"" << name << "\"";
+            s << "m_client->invokeRemoteMethod(" << targetExpr << ", \"" << name << "\"";
             for (int i = 0; i < params.size(); ++i) {
                 s << ", " << wireArg(params.at(i).toObject());
             }
             s << ");\n";
         } else {
-            s << "m_client->invokeRemoteMethod(\"" << moduleName << "\", \"" << name << "\", QVariantList{";
+            s << "m_client->invokeRemoteMethod(" << targetExpr << ", \"" << name << "\", QVariantList{";
             for (int i = 0; i < params.size(); ++i) {
                 s << wireArg(params.at(i).toObject());
                 if (i + 1 < params.size()) s << ", ";
@@ -628,7 +644,7 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
         if (params.size() > 0) s << ", ";
         s << "std::function<void(" << (ret == "void" ? "void" : ret) << ")> callback, Timeout timeout) {\n";
         s << "    if (!callback) return;\n";
-        s << "    m_client->invokeRemoteMethodAsync(\"" << moduleName << "\", \"" << name << "\", ";
+        s << "    m_client->invokeRemoteMethodAsync(" << targetExpr << ", \"" << name << "\", ";
         if (params.size() == 0) {
             s << "QVariantList()";
         } else {

--- a/cpp-generator/legacy/generator_lib.h
+++ b/cpp-generator/legacy/generator_lib.h
@@ -21,6 +21,19 @@ struct ParsedMethod {
 // builder threads through.
 enum class ApiStyle { Qt, Std };
 
+// Whether the generated wrapper targets ONE fixed module (the historical
+// behaviour) or binds to a module name chosen at runtime.
+//   Static — the module name is baked into the ctor + every remote call,
+//            so `<Class>(LogosAPI*)` always talks to that one module.
+//            This is what name-baked dependency wrappers use.
+//   Bound  — the ctor takes `(LogosAPI*, const QString& moduleName)` and
+//            stores it in `m_moduleName`; every remote call routes through
+//            that member. This is what *interface* wrappers use: one
+//            interface, bound to a concrete module name at runtime.
+// Default is Static so existing callers and their generated output are
+// byte-for-byte unchanged.
+enum class BindMode { Static, Bound };
+
 QString toPascalCase(const QString& name);
 QString normalizeType(QString t);
 QString mapParamType(const QString& qtType);
@@ -45,8 +58,13 @@ QString toQVariantConversion(const QString& type, const QString& argExpr);
 // event next to the existing generic `onEvent(name, callback)` channel.
 // The accessor signature uses the apiStyle's type surface for the
 // callback's argument types.
-QString makeHeader(const QString& moduleName, const QString& className, const QJsonArray& methods, ApiStyle apiStyle = ApiStyle::Qt, const QJsonArray& events = {});
-QString makeSource(const QString& moduleName, const QString& className, const QString& headerBaseName, const QJsonArray& methods, ApiStyle apiStyle = ApiStyle::Qt, const QJsonArray& events = {});
+//
+// `bindMode` selects a fixed-module wrapper (Static, default) or a
+// runtime-bound interface wrapper (Bound) — see BindMode above. In Bound
+// mode `moduleName` is used only for the class/file naming the caller
+// already decided; the emitted code never bakes it into a call.
+QString makeHeader(const QString& moduleName, const QString& className, const QJsonArray& methods, ApiStyle apiStyle = ApiStyle::Qt, const QJsonArray& events = {}, BindMode bindMode = BindMode::Static);
+QString makeSource(const QString& moduleName, const QString& className, const QString& headerBaseName, const QJsonArray& methods, ApiStyle apiStyle = ApiStyle::Qt, const QJsonArray& events = {}, BindMode bindMode = BindMode::Static);
 QVector<ParsedMethod> parseProviderHeader(const QString& headerPath, QTextStream& err);
 
 #endif // GENERATOR_LIB_H

--- a/cpp-generator/legacy/main.cpp
+++ b/cpp-generator/legacy/main.cpp
@@ -908,9 +908,25 @@ int legacy_main(int argc, char* argv[])
                 // LOCAL interface_dependencies entries (those without an
                 // `input`) from metadata.json, relative to the metadata dir —
                 // covers non-nix / source-tree builds. Flags win on collision.
-                QVector<InterfaceSpec> ifaceSpecs = parseInterfaceFlags(args);
+                // Dedup --interface flags by name and drop malformed specs:
+                // a repeated interface name would emit duplicate
+                // #include "<name>_api.h" / bind_<name>(...) into logos_sdk.h
+                // and fail to compile, and an empty name/path can only fail
+                // later in a less actionable way.
+                QVector<InterfaceSpec> ifaceSpecs;
                 QSet<QString> haveIface;
-                for (const InterfaceSpec& sp : ifaceSpecs) haveIface.insert(sp.name);
+                for (const InterfaceSpec& sp : parseInterfaceFlags(args)) {
+                    if (sp.name.isEmpty() || sp.path.isEmpty()) {
+                        err << "Ignoring malformed --interface spec (empty name or path)\n";
+                        continue;
+                    }
+                    if (haveIface.contains(sp.name)) {
+                        err << "Ignoring duplicate --interface '" << sp.name << "'\n";
+                        continue;
+                    }
+                    haveIface.insert(sp.name);
+                    ifaceSpecs.append(sp);
+                }
 
                 const QString metaDir = QFileInfo(metaResolvedPath).absolutePath();
                 const QJsonArray ifaceDeps = obj.value("interface_dependencies").toArray();

--- a/cpp-generator/legacy/main.cpp
+++ b/cpp-generator/legacy/main.cpp
@@ -17,6 +17,7 @@
 #include "logos_provider_object.h"
 #include "generator_lib.h"
 #include "../experimental/lidl_parser.h"
+#include "../experimental/impl_header_parser.h"
 
 // Escape a string for safe embedding inside a generated C++ string literal.
 static QString cppStringEscape(const QString& s)
@@ -93,6 +94,208 @@ static QJsonArray loadEventsFromLidl(const QString& lidlPath, QTextStream& err)
         result.append(obj);
     }
     return result;
+}
+
+// ── Dependency interfaces ───────────────────────────────────────────────────
+//
+// An "interface dependency" is a method/event contract a consumer declares
+// (in `metadata.json#interface_dependencies`) decoupled from any concrete
+// module. The definition file is either a `.lidl` or a pure-C++ `.h` (the
+// module's own language). The generator emits a BOUND wrapper class — the
+// target module name is a runtime ctor argument, not baked in — so one
+// interface can be bound to any module that satisfies it.
+
+// A single interface to generate a bound wrapper for. `path` is already
+// resolved (nix resolves local `${src}/file` and remote `${input}/file`
+// store paths and passes them via --interface; the generator never touches
+// flake inputs). `implClass` is required for `.h` files, empty for `.lidl`.
+struct InterfaceSpec {
+    QString name;       // interface identifier → class/file name + bind_<name>
+    QString path;       // resolved path to the .lidl / .h definition
+    QString implClass;  // class inside a .h whose API defines the interface
+};
+
+// Parse all `--interface <name>=<path>[=<impl_class>]` flags. Names and
+// store paths contain no '=', so splitting on the first two '=' is
+// unambiguous.
+static QVector<InterfaceSpec> parseInterfaceFlags(const QStringList& args)
+{
+    QVector<InterfaceSpec> specs;
+    for (int i = 0; i < args.size(); ++i) {
+        QString value;
+        if (args.at(i) == "--interface" && i + 1 < args.size()) {
+            value = args.at(i + 1);
+        } else if (args.at(i).startsWith("--interface=")) {
+            value = args.at(i).section('=', 1);
+        } else {
+            continue;
+        }
+        const int firstEq = value.indexOf('=');
+        if (firstEq <= 0) continue;  // need at least name=path
+        InterfaceSpec spec;
+        spec.name = value.left(firstEq);
+        const int secondEq = value.indexOf('=', firstEq + 1);
+        if (secondEq < 0) {
+            spec.path = value.mid(firstEq + 1);
+        } else {
+            spec.path = value.mid(firstEq + 1, secondEq - firstEq - 1);
+            spec.implClass = value.mid(secondEq + 1);
+        }
+        specs.append(spec);
+    }
+    return specs;
+}
+
+// Build a getMethods()-shaped QJsonArray (the surface makeHeader/makeSource
+// consume) from a parsed ModuleDecl. Every interface method is invokable.
+static QJsonArray moduleMethodsToJson(const ModuleDecl& mod)
+{
+    QJsonArray arr;
+    for (const MethodDecl& m : mod.methods) {
+        QJsonObject o;
+        o["name"] = m.name;
+        o["returnType"] = lidlTypeExprToQtTypeName(m.returnType);
+        o["isInvokable"] = true;
+        QJsonArray params;
+        for (const ParamDecl& p : m.params) {
+            QJsonObject po;
+            po["type"] = lidlTypeExprToQtTypeName(p.type);
+            po["name"] = p.name;
+            params.append(po);
+        }
+        o["parameters"] = params;
+        arr.append(o);
+    }
+    return arr;
+}
+
+// Build the events QJsonArray ({ name, params:[{name,type}] }) — same shape
+// loadEventsFromLidl produces — from a parsed ModuleDecl.
+static QJsonArray moduleEventsToJson(const ModuleDecl& mod)
+{
+    QJsonArray arr;
+    for (const EventDecl& ed : mod.events) {
+        QJsonObject o;
+        o["name"] = ed.name;
+        QJsonArray params;
+        for (const ParamDecl& pd : ed.params) {
+            QJsonObject p;
+            p["name"] = pd.name;
+            p["type"] = lidlTypeExprToQtTypeName(pd.type);
+            params.append(p);
+        }
+        o["params"] = params;
+        arr.append(o);
+    }
+    return arr;
+}
+
+// Parse an interface definition file into a ModuleDecl. `.lidl` parses
+// directly; `.h`/`.hpp` go through the impl-header parser, which needs a
+// metadata.json — we feed it a synthetic one carrying only the interface
+// name so the consumer's identity and events are NOT pulled in (the
+// interface's events come solely from the file's own `logos_events:` block).
+static bool parseInterfaceFile(const InterfaceSpec& spec, const QString& genDirPath,
+                               ModuleDecl& outMod, QTextStream& err)
+{
+    QFileInfo fi(spec.path);
+    if (!fi.exists()) {
+        err << "Interface file not found for '" << spec.name << "': " << spec.path << "\n";
+        return false;
+    }
+    const QString ext = fi.suffix().toLower();
+    if (ext == "lidl") {
+        QFile f(spec.path);
+        if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            err << "Failed to open interface file: " << spec.path << "\n";
+            return false;
+        }
+        const QString src = QString::fromUtf8(f.readAll());
+        f.close();
+        LidlParseResult pr = lidlParse(src);
+        if (pr.hasError()) {
+            err << spec.path << ":" << pr.errorLine << ":" << pr.errorColumn
+                << ": " << pr.error << "\n";
+            return false;
+        }
+        outMod = pr.module;
+        return true;
+    }
+    if (ext == "h" || ext == "hpp") {
+        if (spec.implClass.isEmpty()) {
+            err << "Interface '" << spec.name << "' is a C++ header but no impl_class was given "
+                << "(metadata.json interface_dependencies entry needs \"impl_class\")\n";
+            return false;
+        }
+        // Synthetic minimal metadata: name only, no events — keeps the
+        // consumer's identity/events out of the interface.
+        const QString synthMeta = QDir(genDirPath).filePath("." + spec.name + "_iface_meta.json");
+        {
+            QFile mf(synthMeta);
+            if (!mf.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+                err << "Failed to write temporary interface metadata: " << synthMeta << "\n";
+                return false;
+            }
+            mf.write(QString("{\"name\":\"%1\"}").arg(spec.name).toUtf8());
+            mf.close();
+        }
+        ImplParseResult pr = parseImplHeader(spec.path, spec.implClass, synthMeta, err);
+        QFile::remove(synthMeta);
+        if (pr.hasError()) {
+            err << "Error parsing interface header " << spec.path << ": " << pr.error << "\n";
+            return false;
+        }
+        outMod = pr.module;
+        return true;
+    }
+    err << "Unsupported interface file type for '" << spec.name << "': " << spec.path
+        << " (expected .lidl or .h)\n";
+    return false;
+}
+
+// Generate a bound wrapper (<name>_api.{h,cpp}) for each interface. The
+// wrapper class is named from the interface `name` (PascalCase), NOT the
+// definition file's internal module name, so it matches the #include the
+// umbrella header emits.
+static bool generateInterfaceWrappers(const QVector<InterfaceSpec>& ifaces,
+                                      const QString& genDirPath, ApiStyle apiStyle,
+                                      QTextStream& out, QTextStream& err)
+{
+    for (const InterfaceSpec& spec : ifaces) {
+        ModuleDecl mod;
+        if (!parseInterfaceFile(spec, genDirPath, mod, err)) return false;
+
+        const QString className = toPascalCase(spec.name);
+        const QJsonArray methods = moduleMethodsToJson(mod);
+        const QJsonArray events  = moduleEventsToJson(mod);
+        const QString headerRel = spec.name + "_api.h";
+        const QString sourceRel = spec.name + "_api.cpp";
+
+        const QString header = makeHeader(spec.name, className, methods, apiStyle, events, BindMode::Bound);
+        const QString source = makeSource(spec.name, className, headerRel, methods, apiStyle, events, BindMode::Bound);
+
+        {
+            QFile f(QDir(genDirPath).filePath(headerRel));
+            if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+                err << "Failed to write interface header: " << headerRel << "\n";
+                return false;
+            }
+            f.write(header.toUtf8());
+        }
+        {
+            QFile f(QDir(genDirPath).filePath(sourceRel));
+            if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+                err << "Failed to write interface source: " << sourceRel << "\n";
+                return false;
+            }
+            f.write(source.toUtf8());
+        }
+        out << "Generated bound interface wrapper: " << headerRel << " (class "
+            << className << ", " << methods.size() << " methods, "
+            << events.size() << " events)\n";
+    }
+    out.flush();
+    return true;
 }
 
 static QJsonArray enumerateMethods(QObject* moduleInstance)
@@ -200,7 +403,7 @@ static bool writeUmbrellaHeader(const QString& genDirPath, QTextStream& err)
     return true;
 }
 
-static bool writeUmbrellaHeaderFromDeps(const QString& genDirPath, const QJsonArray& deps, QTextStream& err)
+static bool writeUmbrellaHeaderFromDeps(const QString& genDirPath, const QJsonArray& deps, const QStringList& interfaceNames, QTextStream& err)
 {
     // Generate logos_sdk.h from metadata.json's dependencies list. The
     // shape doesn't depend on apiStyle — each dep emits a single
@@ -212,16 +415,28 @@ static bool writeUmbrellaHeaderFromDeps(const QString& genDirPath, const QJsonAr
     // dependencies` are exposed. Apps that need to manage the core
     // (basecamp, logoscore) use liblogos' C API directly rather than
     // the typed `LogosModules` aggregate.
+    //
+    // Interface dependencies (`metadata.json#interface_dependencies`) are
+    // NOT fixed members — they bind to a runtime-chosen module — so each
+    // gets a `bind_<name>(moduleName)` factory instead, returning a bound
+    // wrapper by value.
     QDir genDir(genDirPath);
     QString content;
     QTextStream s(&content);
     s << "#pragma once\n";
+    // <string> is only needed for the std::string bind_<iface> overloads;
+    // omit it when there are no interfaces so the umbrella stays identical
+    // to its historical form for dependency-only modules.
+    if (!interfaceNames.isEmpty()) s << "#include <string>\n";
     s << "#include \"logos_api.h\"\n";
     s << "#include \"logos_api_client.h\"\n\n";
     for (const QJsonValue& v : deps) {
         if (!v.isString()) continue;
         QString depName = v.toString();
         s << "#include \"" << depName << "_api.h\"\n";
+    }
+    for (const QString& ifaceName : interfaceNames) {
+        s << "#include \"" << ifaceName << "_api.h\"\n";
     }
     s << "\n";
 
@@ -239,6 +454,18 @@ static bool writeUmbrellaHeaderFromDeps(const QString& genDirPath, const QJsonAr
         QString depName = v.toString();
         QString className = toPascalCase(depName);
         s << "    " << className << " " << depName << ";\n";
+    }
+    // Bind factories — one per interface dependency. Two overloads so
+    // both Qt-typed (QString) and std-typed (std::string) call sites can
+    // pass the runtime module name without converting at the call site.
+    for (const QString& ifaceName : interfaceNames) {
+        const QString className = toPascalCase(ifaceName);
+        s << "    " << className << " bind_" << ifaceName << "(const QString& moduleName) {\n";
+        s << "        return " << className << "(api, moduleName);\n";
+        s << "    }\n";
+        s << "    " << className << " bind_" << ifaceName << "(const std::string& moduleName) {\n";
+        s << "        return " << className << "(api, QString::fromStdString(moduleName));\n";
+        s << "    }\n";
     }
     s << "};\n";
 
@@ -283,11 +510,12 @@ static bool writeUmbrellaSource(const QString& genDirPath, QTextStream& err)
     return true;
 }
 
-static bool writeUmbrellaSourceFromDeps(const QString& genDirPath, const QJsonArray& deps, QTextStream& err)
+static bool writeUmbrellaSourceFromDeps(const QString& genDirPath, const QJsonArray& deps, const QStringList& interfaceNames, QTextStream& err)
 {
     // Generate logos_sdk.cpp from metadata.json's dependencies list.
     // Each dep emits one wrapper `.cpp` (Qt or std — decided at codegen
     // time, file name is the same either way), `#include`'d here.
+    // Interface wrappers (`<name>_api.cpp`) are #include'd the same way.
     QDir genDir(genDirPath);
     QString content;
     QTextStream s(&content);
@@ -296,6 +524,9 @@ static bool writeUmbrellaSourceFromDeps(const QString& genDirPath, const QJsonAr
         if (!v.isString()) continue;
         QString depName = v.toString();
         s << "#include \"" << depName << "_api.cpp\"\n";
+    }
+    for (const QString& ifaceName : interfaceNames) {
+        s << "#include \"" << ifaceName << "_api.cpp\"\n";
     }
     s << "\n";
 
@@ -670,11 +901,57 @@ int legacy_main(int argc, char* argv[])
                 QString genDirPath = outputDir.isEmpty() ? QDir::current().filePath("logos-cpp-sdk/cpp/generated") : outputDir;
                 QDir().mkpath(genDirPath);
 
-                // Generate umbrella headers based on dependencies from metadata
-                if (!writeUmbrellaHeaderFromDeps(genDirPath, deps, err)) {
+                // Collect interface dependencies. Primary source: --interface
+                // flags (nix resolves both local `${src}/file` and remote
+                // `${input}/file` store paths and passes them here, so the
+                // generator never touches flake inputs). Fallback: self-resolve
+                // LOCAL interface_dependencies entries (those without an
+                // `input`) from metadata.json, relative to the metadata dir —
+                // covers non-nix / source-tree builds. Flags win on collision.
+                QVector<InterfaceSpec> ifaceSpecs = parseInterfaceFlags(args);
+                QSet<QString> haveIface;
+                for (const InterfaceSpec& sp : ifaceSpecs) haveIface.insert(sp.name);
+
+                const QString metaDir = QFileInfo(metaResolvedPath).absolutePath();
+                const QJsonArray ifaceDeps = obj.value("interface_dependencies").toArray();
+                for (const QJsonValue& v : ifaceDeps) {
+                    if (!v.isObject()) continue;
+                    const QJsonObject eo = v.toObject();
+                    const QString name = eo.value("name").toString();
+                    if (name.isEmpty() || haveIface.contains(name)) continue;
+                    // Entries with an `input` reference another repo (flake
+                    // input); only nix can resolve those, via a --interface
+                    // flag. If we reach here without a matching flag, skip.
+                    if (eo.contains("input")) {
+                        err << "Note: interface '" << name << "' has an 'input' (cross-repo) "
+                            << "but no --interface flag was passed; skipping (nix supplies the path).\n";
+                        continue;
+                    }
+                    const QString file = eo.value("file").toString();
+                    if (file.isEmpty()) continue;
+                    InterfaceSpec spec;
+                    spec.name = name;
+                    spec.path = QDir(metaDir).filePath(file);
+                    spec.implClass = eo.value("impl_class").toString();
+                    ifaceSpecs.append(spec);
+                    haveIface.insert(name);
+                }
+
+                // Generate one bound wrapper (<name>_api.{h,cpp}) per interface.
+                if (!ifaceSpecs.isEmpty()) {
+                    if (!generateInterfaceWrappers(ifaceSpecs, genDirPath, apiStyle, out, err)) {
+                        return 9;
+                    }
+                }
+
+                QStringList interfaceNames;
+                for (const InterfaceSpec& sp : ifaceSpecs) interfaceNames.append(sp.name);
+
+                // Generate umbrella headers based on dependencies + interfaces
+                if (!writeUmbrellaHeaderFromDeps(genDirPath, deps, interfaceNames, err)) {
                     return 7;
                 }
-                if (!writeUmbrellaSourceFromDeps(genDirPath, deps, err)) {
+                if (!writeUmbrellaSourceFromDeps(genDirPath, deps, interfaceNames, err)) {
                     return 8;
                 }
 


### PR DESCRIPTION
## Dependency interfaces — SDK / code generator

Part of a cross-repo feature: a module declares a *header interface* (methods + events) decoupled from any concrete module, then binds it to a module name **at runtime** via typed accessors.

```cpp
auto calc = modules().bind_calculator("calc_module");   // runtime choice
calc.add(3, 5);                                          // sync
calc.fibonacciAsync(20, [](int64_t v){ /* ... */ });     // async
calc.onVersionReady([](const std::string& v){ /* ... */ }); // typed event
```

### This PR (the generator)
- **`BindMode { Static, Bound }`** in `generator_lib` — a bound wrapper's ctor takes `(LogosAPI*, const QString& moduleName)` and every `invokeRemoteMethod*` / `ensureReplica` routes through `m_moduleName`. Default `Static` keeps existing name-baked output **byte-for-byte unchanged**.
- **`--interface <name>=<path>[=<impl_class>]`** in `legacy/main.cpp` (consumed by `--general-only`): parses a `.lidl` or pure-C++ `.h` interface, emits the bound `<name>_api.{h,cpp}`, and adds `bind_<name>(...)` factories (QString + std::string) to the `LogosModules` umbrella. Also self-resolves local `interface_dependencies` from `metadata.json` for non-nix builds.
- **`BindMode` parity** for the experimental `--lidl` generator.

### Cross-repo chain (merge order)
1. **logos-cpp-sdk** ← this PR
2. logos-module-builder — parses `interface_dependencies`, resolves local/cross-repo paths
3. logos-plugin-qt — passes `--interface` flags through the build
4. logos-test-modules — verification consumer
5. logos-tutorial — executable tutorial

> Branched off `proper-handling-of-reserved-words`; those commits appear in this diff until that work lands on master.

### Verification
Generator unit tests: bound ctor, all calls via `m_moduleName` (no baked literal), `bind_<name>` factory, Qt + std styles, `.h` ≡ `.lidl` output, consumer's own events don't leak into the interface. Deps-only umbrella verified unchanged. A downstream module with an interface dependency builds end-to-end through nix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
