### PR TITLE
feat: LIDL interface IR — --header-to-lidl frontend + --dep backend

### DIFF
--- a/cpp-generator/legacy/main.cpp
+++ b/cpp-generator/legacy/main.cpp
@@ -255,12 +255,10 @@ static bool parseInterfaceFile(const InterfaceSpec& spec, const QString& genDirP
     return false;
 }
 
-// Generate a bound wrapper (<name>_api.{h,cpp}) for each interface. The
-// wrapper class is named from the interface `name` (PascalCase), NOT the
-// definition file's internal module name, so it matches the #include the
-// umbrella header emits.
 // Generate a wrapper (`<name>_api.{h,cpp}`) per spec from its definition file.
-// `bindMode` picks the wrapper flavour:
+// The wrapper class is named from the spec `name` (PascalCase), NOT the
+// definition file's internal module name, so it matches the `#include` the
+// umbrella header emits. `bindMode` picks the wrapper flavour:
 //   Bound  — interface dependency: ctor takes a runtime module name; exposed
 //            via a `bind_<name>(...)` factory on the umbrella.
 //   Static — concrete dependency: the module name is baked in; exposed as a

--- a/cpp-generator/legacy/main.cpp
+++ b/cpp-generator/legacy/main.cpp
@@ -115,17 +115,19 @@ struct InterfaceSpec {
     QString implClass;  // class inside a .h whose API defines the interface
 };
 
-// Parse all `--interface <name>=<path>[=<impl_class>]` flags. Names and
-// store paths contain no '=', so splitting on the first two '=' is
-// unambiguous.
-static QVector<InterfaceSpec> parseInterfaceFlags(const QStringList& args)
+// Parse all `<flag> <name>=<path>[=<impl_class>]` (or `<flag>=<name>=...`)
+// occurrences. Names and store paths contain no '=', so splitting on the
+// first two '=' is unambiguous. Used for both `--interface` (runtime-bound
+// wrappers) and `--dep` (name-baked wrappers generated from a dep's LIDL).
+static QVector<InterfaceSpec> parseSpecFlags(const QStringList& args, const QString& flag)
 {
+    const QString flagEq = flag + "=";
     QVector<InterfaceSpec> specs;
     for (int i = 0; i < args.size(); ++i) {
         QString value;
-        if (args.at(i) == "--interface" && i + 1 < args.size()) {
+        if (args.at(i) == flag && i + 1 < args.size()) {
             value = args.at(i + 1);
-        } else if (args.at(i).startsWith("--interface=")) {
+        } else if (args.at(i).startsWith(flagEq)) {
             value = args.at(i).section('=', 1);
         } else {
             continue;
@@ -257,9 +259,17 @@ static bool parseInterfaceFile(const InterfaceSpec& spec, const QString& genDirP
 // wrapper class is named from the interface `name` (PascalCase), NOT the
 // definition file's internal module name, so it matches the #include the
 // umbrella header emits.
+// Generate a wrapper (`<name>_api.{h,cpp}`) per spec from its definition file.
+// `bindMode` picks the wrapper flavour:
+//   Bound  — interface dependency: ctor takes a runtime module name; exposed
+//            via a `bind_<name>(...)` factory on the umbrella.
+//   Static — concrete dependency: the module name is baked in; exposed as a
+//            `<name>` member on the umbrella (byte-identical to the wrapper the
+//            dep's prebuilt headers used to ship).
 static bool generateInterfaceWrappers(const QVector<InterfaceSpec>& ifaces,
                                       const QString& genDirPath, ApiStyle apiStyle,
-                                      QTextStream& out, QTextStream& err)
+                                      QTextStream& out, QTextStream& err,
+                                      BindMode bindMode = BindMode::Bound)
 {
     for (const InterfaceSpec& spec : ifaces) {
         ModuleDecl mod;
@@ -271,13 +281,13 @@ static bool generateInterfaceWrappers(const QVector<InterfaceSpec>& ifaces,
         const QString headerRel = spec.name + "_api.h";
         const QString sourceRel = spec.name + "_api.cpp";
 
-        const QString header = makeHeader(spec.name, className, methods, apiStyle, events, BindMode::Bound);
-        const QString source = makeSource(spec.name, className, headerRel, methods, apiStyle, events, BindMode::Bound);
+        const QString header = makeHeader(spec.name, className, methods, apiStyle, events, bindMode);
+        const QString source = makeSource(spec.name, className, headerRel, methods, apiStyle, events, bindMode);
 
         {
             QFile f(QDir(genDirPath).filePath(headerRel));
             if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
-                err << "Failed to write interface header: " << headerRel << "\n";
+                err << "Failed to write wrapper header: " << headerRel << "\n";
                 return false;
             }
             f.write(header.toUtf8());
@@ -285,14 +295,14 @@ static bool generateInterfaceWrappers(const QVector<InterfaceSpec>& ifaces,
         {
             QFile f(QDir(genDirPath).filePath(sourceRel));
             if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
-                err << "Failed to write interface source: " << sourceRel << "\n";
+                err << "Failed to write wrapper source: " << sourceRel << "\n";
                 return false;
             }
             f.write(source.toUtf8());
         }
-        out << "Generated bound interface wrapper: " << headerRel << " (class "
-            << className << ", " << methods.size() << " methods, "
-            << events.size() << " events)\n";
+        out << "Generated " << (bindMode == BindMode::Bound ? "bound interface" : "dependency")
+            << " wrapper: " << headerRel << " (class " << className << ", "
+            << methods.size() << " methods, " << events.size() << " events)\n";
     }
     out.flush();
     return true;
@@ -915,7 +925,7 @@ int legacy_main(int argc, char* argv[])
                 // later in a less actionable way.
                 QVector<InterfaceSpec> ifaceSpecs;
                 QSet<QString> haveIface;
-                for (const InterfaceSpec& sp : parseInterfaceFlags(args)) {
+                for (const InterfaceSpec& sp : parseSpecFlags(args, "--interface")) {
                     if (sp.name.isEmpty() || sp.path.isEmpty()) {
                         err << "Ignoring malformed --interface spec (empty name or path)\n";
                         continue;
@@ -956,6 +966,38 @@ int legacy_main(int argc, char* argv[])
                 // Generate one bound wrapper (<name>_api.{h,cpp}) per interface.
                 if (!ifaceSpecs.isEmpty()) {
                     if (!generateInterfaceWrappers(ifaceSpecs, genDirPath, apiStyle, out, err)) {
+                        return 9;
+                    }
+                }
+
+                // Concrete dependencies generated from their published LIDL
+                // (`--dep <name>=<lidl>`). Same backend as interfaces but
+                // BindMode::Static — the module name is baked in and the dep is
+                // exposed as a `<dep>` MEMBER (the umbrella already emits it from
+                // `dependencies`, so no umbrella change). nix passes `--dep` only
+                // for deps that publish a `lidl` output; deps without one fall
+                // back to the header-copy path and are NOT passed here. Dedup vs
+                // each other and vs interface names.
+                QVector<InterfaceSpec> depSpecs;
+                QSet<QString> haveDep;
+                for (const InterfaceSpec& sp : parseSpecFlags(args, "--dep")) {
+                    if (sp.name.isEmpty() || sp.path.isEmpty()) {
+                        err << "Ignoring malformed --dep spec (empty name or path)\n";
+                        continue;
+                    }
+                    if (haveIface.contains(sp.name)) {
+                        err << "Ignoring --dep '" << sp.name << "' (name already used by an interface)\n";
+                        continue;
+                    }
+                    if (haveDep.contains(sp.name)) {
+                        err << "Ignoring duplicate --dep '" << sp.name << "'\n";
+                        continue;
+                    }
+                    haveDep.insert(sp.name);
+                    depSpecs.append(sp);
+                }
+                if (!depSpecs.isEmpty()) {
+                    if (!generateInterfaceWrappers(depSpecs, genDirPath, apiStyle, out, err, BindMode::Static)) {
                         return 9;
                     }
                 }

--- a/cpp-generator/main.cpp
+++ b/cpp-generator/main.cpp
@@ -34,12 +34,16 @@ int main(int argc, char* argv[])
         QTextStream out(stdout);
         const QStringList args = app.arguments();
 
+        // Strip a leading '@' from path arguments — some build drivers pass
+        // `@/abs/path`. Matches the legacy_main path handling.
+        auto stripAt = [](QString p) { if (p.startsWith('@')) p.remove(0, 1); return p; };
+
         const int idx = args.indexOf("--header-to-lidl");
         if (idx + 1 >= args.size()) {
             err << "Error: --header-to-lidl requires a path to the impl header\n";
             return 1;
         }
-        const QString headerPath = args.at(idx + 1);
+        const QString headerPath = stripAt(args.at(idx + 1));
 
         const int implClassIdx = args.indexOf("--impl-class");
         if (implClassIdx == -1 || implClassIdx + 1 >= args.size()) {
@@ -53,7 +57,7 @@ int main(int argc, char* argv[])
             err << "Error: --header-to-lidl requires --metadata <metadata.json>\n";
             return 1;
         }
-        const QString metadataPath = args.at(metadataIdx + 1);
+        const QString metadataPath = stripAt(args.at(metadataIdx + 1));
 
         ImplParseResult pr = parseImplHeader(headerPath, implClass, metadataPath, err);
         if (pr.hasError()) {
@@ -69,12 +73,13 @@ int main(int argc, char* argv[])
         const int outputIdx = args.indexOf("--output");
         const int outDirIdx = args.indexOf("--output-dir");
         if (oIdx != -1 && oIdx + 1 < args.size()) {
-            outPath = args.at(oIdx + 1);
+            outPath = stripAt(args.at(oIdx + 1));
         } else if (outputIdx != -1 && outputIdx + 1 < args.size()) {
-            outPath = args.at(outputIdx + 1);
+            outPath = stripAt(args.at(outputIdx + 1));
         } else if (outDirIdx != -1 && outDirIdx + 1 < args.size()) {
-            QDir().mkpath(args.at(outDirIdx + 1));
-            outPath = QDir(args.at(outDirIdx + 1)).filePath(mod.name + ".lidl");
+            const QString d = stripAt(args.at(outDirIdx + 1));
+            QDir().mkpath(d);
+            outPath = QDir(d).filePath(mod.name + ".lidl");
         } else {
             outPath = mod.name + ".lidl";
         }

--- a/cpp-generator/main.cpp
+++ b/cpp-generator/main.cpp
@@ -12,14 +12,84 @@
 
 int main(int argc, char* argv[])
 {
-    // Check for --lidl or --from-header mode before initializing QCoreApplication,
-    // since legacy_main creates its own.
+    // Check for --lidl / --from-header / --header-to-lidl mode before
+    // initializing QCoreApplication, since legacy_main creates its own.
     bool hasLidl = false;
     bool hasFromHeader = false;
+    bool hasHeaderToLidl = false;
     for (int i = 1; i < argc; ++i) {
         QString arg = QString::fromUtf8(argv[i]);
         if (arg == "--lidl") hasLidl = true;
         if (arg == "--from-header") hasFromHeader = true;
+        if (arg == "--header-to-lidl") hasHeaderToLidl = true;
+    }
+
+    // --header-to-lidl: the C++ frontend of the source -> LIDL -> bindings
+    // pipeline. Parse an impl header and emit ONLY its LIDL contract (no Qt
+    // glue / dispatch), so a module can publish a cheap `lidl` artifact that
+    // consumers (any language) turn into bindings without building the module.
+    if (hasHeaderToLidl) {
+        QCoreApplication app(argc, argv);
+        QTextStream err(stderr);
+        QTextStream out(stdout);
+        const QStringList args = app.arguments();
+
+        const int idx = args.indexOf("--header-to-lidl");
+        if (idx + 1 >= args.size()) {
+            err << "Error: --header-to-lidl requires a path to the impl header\n";
+            return 1;
+        }
+        const QString headerPath = args.at(idx + 1);
+
+        const int implClassIdx = args.indexOf("--impl-class");
+        if (implClassIdx == -1 || implClassIdx + 1 >= args.size()) {
+            err << "Error: --header-to-lidl requires --impl-class <ClassName>\n";
+            return 1;
+        }
+        const QString implClass = args.at(implClassIdx + 1);
+
+        const int metadataIdx = args.indexOf("--metadata");
+        if (metadataIdx == -1 || metadataIdx + 1 >= args.size()) {
+            err << "Error: --header-to-lidl requires --metadata <metadata.json>\n";
+            return 1;
+        }
+        const QString metadataPath = args.at(metadataIdx + 1);
+
+        ImplParseResult pr = parseImplHeader(headerPath, implClass, metadataPath, err);
+        if (pr.hasError()) {
+            err << "Error parsing impl header: " << pr.error << "\n";
+            return 4;
+        }
+        const ModuleDecl& mod = pr.module;
+
+        // Output path: explicit -o/--output <file>, else <output-dir>/<name>.lidl,
+        // else <name>.lidl in the CWD.
+        QString outPath;
+        const int oIdx = args.indexOf("-o");
+        const int outputIdx = args.indexOf("--output");
+        const int outDirIdx = args.indexOf("--output-dir");
+        if (oIdx != -1 && oIdx + 1 < args.size()) {
+            outPath = args.at(oIdx + 1);
+        } else if (outputIdx != -1 && outputIdx + 1 < args.size()) {
+            outPath = args.at(outputIdx + 1);
+        } else if (outDirIdx != -1 && outDirIdx + 1 < args.size()) {
+            QDir().mkpath(args.at(outDirIdx + 1));
+            outPath = QDir(args.at(outDirIdx + 1)).filePath(mod.name + ".lidl");
+        } else {
+            outPath = mod.name + ".lidl";
+        }
+
+        QFile f(outPath);
+        if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+            err << "Failed to write LIDL: " << outPath << "\n";
+            return 5;
+        }
+        f.write(lidlSerialize(mod).toUtf8());
+        f.close();
+        out << "Generated LIDL: " << outPath << " (" << mod.methods.size()
+            << " methods, " << mod.events.size() << " events)\n";
+        out.flush();
+        return 0;
     }
 
     if (hasLidl || hasFromHeader) {


### PR DESCRIPTION
## LIDL as the universal interface IR (generator side)

Part of "consume concrete dependencies via LIDL" — building a consumer should no longer build its dependency *modules*; instead a dependency publishes a cheap LIDL contract and consumers generate bindings from it. Every binding now flows **source → LIDL → C++**, so a future module in another language plugs into the same backend (**Rust → LIDL → C++**).

### This PR (generator)
- **`--header-to-lidl <impl.h> --impl-class <X> --metadata <m.json> -o <out.lidl>`** — the standalone C++ frontend: `parseImplHeader → lidlSerialize`, emitting **only** the `<name>.lidl` (no Qt glue/dispatch). This is what a module's cheap `packages.<sys>.lidl` output runs.
- **`--dep <name>=<lidl>`** — the LIDL backend for concrete deps: reuses the interface-wrapper path with `BindMode::Static`, emitting the name-baked `modules().<dep>` wrapper from the dep's published LIDL. The umbrella already emits the `<dep>` member, so no umbrella change.
- `generateInterfaceWrappers` gains a `BindMode` param (default `Bound`); `parseInterfaceFlags` generalized to `parseSpecFlags(args, flag)` for `--interface` and `--dep`. `--dep` specs are deduped against each other and against `--interface` names.

### Cross-repo chain (merge order)
1. **logos-cpp-sdk** ← this PR
2. logos-plugin-qt — pass `--dep` flags from the build
3. logos-module-builder — publish `packages.<sys>.lidl`; classify deps (LIDL vs transitional header-copy fallback)

### Verification
Standalone: `header → LIDL → Static wrapper` produces the correct name-baked `modules().<dep>` wrapper (verified 41 methods + 2 events for `test_basic_module_cpp`). The generator's own test suite passes (`ws test logos-cpp-sdk --auto-local`), and a downstream mixed consumer builds + runs end-to-end (see the module-builder PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
