### PR TITLE
fix: parse declarations on same line as `logos_events:` / access specifier (#76)

### DIFF
--- a/cpp-generator/experimental/impl_header_parser.cpp
+++ b/cpp-generator/experimental/impl_header_parser.cpp
@@ -322,26 +322,39 @@ ImplParseResult parseImplHeader(const QString& headerPath,
                 }
             }
 
+            // A section specifier may be followed by a declaration on the
+            // *same* physical line — e.g. clang-format / prettier collapse
+            //     logos_events:
+            //         void versionReady(const std::string& version);
+            // into `logos_events : void versionReady(const std::string& version);`.
+            // Strip any leading specifiers, updating the section state, and
+            // let whatever remains fall through to the declaration parser
+            // below — otherwise everything after the colon is discarded and
+            // the same valid C++ is parsed differently based on formatting.
+            //
             // `logos_events:` takes precedence over the standard access
             // specifiers: it's a separate section that the codegen pulls
             // event prototypes from. (At preprocess time, `logos_events`
             // expands to `public`, but the raw source still carries the
             // token we recognise here.)
-            if (eventsRe.match(line).hasMatch()) {
-                state = InLogosEvents;
-                pendingDoc.clear();
-                break;
-            }
-
-            {
+            while (true) {
+                QRegularExpressionMatch em = eventsRe.match(line);
+                if (em.hasMatch()) {
+                    state = InLogosEvents;
+                    pendingDoc.clear();
+                    line = line.mid(em.capturedEnd()).trimmed();
+                    continue;
+                }
                 QRegularExpressionMatch am = accessRe.match(line);
                 if (am.hasMatch()) {
                     QString spec = am.captured(1);
                     if (spec == "public") state = InPublic;
                     else state = InPrivate;
                     pendingDoc.clear();
-                    break;
+                    line = line.mid(am.capturedEnd()).trimmed();
+                    continue;
                 }
+                break;
             }
 
             // Only doc comments (/// or /** ... */ / /*! ... */) accumulate as

--- a/cpp-generator/experimental/impl_header_parser.cpp
+++ b/cpp-generator/experimental/impl_header_parser.cpp
@@ -337,12 +337,13 @@ ImplParseResult parseImplHeader(const QString& headerPath,
             // event prototypes from. (At preprocess time, `logos_events`
             // expands to `public`, but the raw source still carries the
             // token we recognise here.)
+            bool specifierStripped = false;
             while (true) {
                 QRegularExpressionMatch em = eventsRe.match(line);
                 if (em.hasMatch()) {
                     state = InLogosEvents;
-                    pendingDoc.clear();
                     line = line.mid(em.capturedEnd()).trimmed();
+                    specifierStripped = true;
                     continue;
                 }
                 QRegularExpressionMatch am = accessRe.match(line);
@@ -350,12 +351,22 @@ ImplParseResult parseImplHeader(const QString& headerPath,
                     QString spec = am.captured(1);
                     if (spec == "public") state = InPublic;
                     else state = InPrivate;
-                    pendingDoc.clear();
                     line = line.mid(am.capturedEnd()).trimmed();
+                    specifierStripped = true;
                     continue;
                 }
                 break;
             }
+            // A *bare* specifier (nothing after the colon) is a section
+            // boundary and resets any pending doc-comment, mirroring Qt's
+            // `signals:`. But when a declaration shares the line, the doc
+            // comment preceding the whole line must still attach to that
+            // declaration — otherwise documentation, like the declaration
+            // itself (#76), would become formatting-dependent. So only clear
+            // here for the bare form; the same-line form keeps pendingDoc and
+            // attaches it in the declaration parser below.
+            if (specifierStripped && line.isEmpty())
+                pendingDoc.clear();
 
             // Only doc comments (/// or /** ... */ / /*! ... */) accumulate as
             // the pending description for the next method. Plain // and /*

--- a/tests/experimental/fixtures/same_line_events_impl.h
+++ b/tests/experimental/fixtures/same_line_events_impl.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <string>
+#include <cstdint>
+
+// Parser tests only read this as text. Regression fixture for issue #76:
+// a section specifier and a declaration collapsed onto one *physical* line
+// (as clang-format / prettier produce) must be parsed exactly like the
+// newline-separated form. The code after the colon must NOT be discarded,
+// otherwise the same valid C++ is processed differently based on formatting.
+class SameLineEventsImpl {
+public:
+    SameLineEventsImpl() = default;
+
+    // Access specifier + declaration on one line: the method is still found.
+    public: std::string greet(const std::string& name);
+
+    // The exact prettier-formatted form from the issue: `logos_events`,
+    // a space, the colon, then the event prototype — all on one line.
+    logos_events : void versionReady(const std::string &version);
+
+    // A further event after the section is already open (still same-line).
+    void downloadProgress(const std::string &id, int64_t percent);
+
+    // The newline-separated form keeps working alongside the collapsed form.
+logos_events:
+    void shutdown();
+};

--- a/tests/experimental/fixtures/same_line_events_impl.h
+++ b/tests/experimental/fixtures/same_line_events_impl.h
@@ -15,7 +15,11 @@ public:
     public: std::string greet(const std::string& name);
 
     // The exact prettier-formatted form from the issue: `logos_events`,
-    // a space, the colon, then the event prototype — all on one line.
+    // a space, the colon, then the event prototype — all on one line. The
+    // `///` doc comment above must still attach to the event: in the
+    // collapsed form there is nowhere else to put it, so dropping it would
+    // make documentation formatting-dependent too.
+    /// Fired once the latest version is known.
     logos_events : void versionReady(const std::string &version);
 
     // A further event after the section is already open (still same-line).

--- a/tests/experimental/fixtures/same_line_events_metadata.json
+++ b/tests/experimental/fixtures/same_line_events_metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "same_line_events_mod",
+  "version": "1.0.0",
+  "description": "Fixture for same-line section specifiers (issue #76)",
+  "category": "test",
+  "dependencies": []
+}

--- a/tests/experimental/test_impl_header_parser.cpp
+++ b/tests/experimental/test_impl_header_parser.cpp
@@ -349,3 +349,70 @@ TEST_F(ImplHeaderParserTest, EventDocCommentsFromHeader)
     EXPECT_EQ(r.module.events[2].name, "shutdown");
     EXPECT_EQ(r.module.events[2].description, "Single-line documented event.");
 }
+
+// ---------------------------------------------------------------------------
+// Issue #76: a section specifier and a declaration on the *same* physical
+// line (`logos_events : void foo();`, as clang-format / prettier produce)
+// must be parsed identically to the newline-separated form. The code after
+// the colon must not be discarded.
+// ---------------------------------------------------------------------------
+
+TEST_F(ImplHeaderParserTest, SameLineSectionSpecifiers)
+{
+    auto r = parseImplHeader(
+        fixturesDir() + "/same_line_events_impl.h",
+        "SameLineEventsImpl",
+        fixturesDir() + "/same_line_events_metadata.json",
+        err);
+    ASSERT_FALSE(r.hasError()) << r.error.toStdString();
+
+    auto findEvent = [&](const QString& name) -> const EventDecl* {
+        for (const auto& e : r.module.events)
+            if (e.name == name) return &e;
+        return nullptr;
+    };
+    auto findMethod = [&](const QString& name) -> const MethodDecl* {
+        for (const auto& m : r.module.methods)
+            if (m.name == name) return &m;
+        return nullptr;
+    };
+
+    // The exact prettier form from the issue:
+    //     logos_events : void versionReady(const std::string &version);
+    // Previously the prototype after the colon was discarded entirely.
+    const EventDecl* versionReady = findEvent("versionReady");
+    ASSERT_NE(versionReady, nullptr)
+        << "Same-line `logos_events :` prototype must still be parsed";
+    ASSERT_EQ(versionReady->params.size(), 1);
+    EXPECT_EQ(versionReady->params[0].name, "version");
+    EXPECT_EQ(versionReady->params[0].type.name, "tstr");
+
+    // An event declared after the section is already open, also same-line.
+    const EventDecl* downloadProgress = findEvent("downloadProgress");
+    ASSERT_NE(downloadProgress, nullptr);
+    ASSERT_EQ(downloadProgress->params.size(), 2);
+    EXPECT_EQ(downloadProgress->params[0].name, "id");
+    EXPECT_EQ(downloadProgress->params[0].type.name, "tstr");
+    EXPECT_EQ(downloadProgress->params[1].name, "percent");
+    EXPECT_EQ(downloadProgress->params[1].type.name, "int");
+
+    // The newline-separated form keeps working alongside the collapsed form.
+    EXPECT_NE(findEvent("shutdown"), nullptr);
+
+    // Exactly the three events above — no phantom or dropped entries.
+    EXPECT_EQ(r.module.events.size(), 3);
+
+    // The symmetric case: `public : <decl>` on one line must surface the
+    // method too (the access specifier no longer swallows the declaration).
+    const MethodDecl* greet = findMethod("greet");
+    ASSERT_NE(greet, nullptr)
+        << "Same-line `public:` declaration must still be parsed";
+    EXPECT_EQ(greet->returnType.name, "tstr");
+    ASSERT_EQ(greet->params.size(), 1);
+    EXPECT_EQ(greet->params[0].name, "name");
+    EXPECT_EQ(greet->params[0].type.name, "tstr");
+
+    // The same-line events must land in events[], never leak into methods[].
+    EXPECT_EQ(findMethod("versionReady"), nullptr);
+    EXPECT_EQ(findMethod("downloadProgress"), nullptr);
+}

--- a/tests/experimental/test_impl_header_parser.cpp
+++ b/tests/experimental/test_impl_header_parser.cpp
@@ -386,6 +386,10 @@ TEST_F(ImplHeaderParserTest, SameLineSectionSpecifiers)
     ASSERT_EQ(versionReady->params.size(), 1);
     EXPECT_EQ(versionReady->params[0].name, "version");
     EXPECT_EQ(versionReady->params[0].type.name, "tstr");
+    // The `///` doc comment above the collapsed line must attach: in the
+    // same-line form there is nowhere else for it to go, so documentation
+    // must not be formatting-dependent either.
+    EXPECT_EQ(versionReady->description, "Fired once the latest version is known.");
 
     // An event declared after the section is already open, also same-line.
     const EventDecl* downloadProgress = findEvent("downloadProgress");


### PR DESCRIPTION
## Problem

Fixes #76. The experimental impl header parser ([`cpp-generator/experimental/impl_header_parser.cpp`](https://github.com/logos-co/logos-cpp-sdk/blob/master/cpp-generator/experimental/impl_header_parser.cpp)) discarded any code after a section specifier when the specifier and a declaration shared one physical line.

So the clang-format / prettier output:

```cpp
logos_events : void versionReady(const std::string &version);
```

silently dropped `versionReady`, while the newline-separated form generated it — the same valid C++ was parsed differently based purely on formatting. The same latent bug affected `public:` / `private:` declarations collapsed onto one line.

## Fix

On matching a section specifier the parser set its state and immediately `break`'d out of line processing. Replaced that with a small loop that strips any leading `logos_events:` / `public:` / `private:` specifiers, updates the section state, then lets the **remainder of the line fall through** to the existing declaration parser.

- Brace counting still happens once per physical line.
- Blank-line / bare-specifier doc-comment reset is preserved (adjacent-only doc capture unchanged).
- Purely additive: the newline-separated form parses exactly as before.

## Tests

Added `SameLineSectionSpecifiers` to `tests/experimental/test_impl_header_parser.cpp` with new fixtures (`same_line_events_impl.h` + metadata). It asserts:

- the exact prettier form from the issue parses, with correct param name/type;
- a follow-on same-line event in an already-open `logos_events:` section parses;
- the newline-separated form still works alongside the collapsed form;
- the symmetric inline `public:` method surfaces;
- same-line events land in `events[]` and never leak into `methods[]`.

## Verification

- Built the suite via nix; **all 11 `ImplHeaderParserTest` tests pass**, including the new one. No regressions.
- Confirmed the test is meaningful: reverting the parser fix makes `SameLineSectionSpecifiers` fail; restoring it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)