### PR TITLE
ci: drop doctest chain pins (qt-split chain fully merged)

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -118,8 +118,6 @@ jobs:
             --verbose \
             --continue-on-fail \
             --release-for logos-cpp-sdk=${{ steps.commit.outputs.sha }} \
-            --release-for logos-logoscore-cli=f1a6294d86aa46257b106d6f08c9bed9f940c3eb \
-            --release-for logos-module-builder=c849834b9d7b7eff1f94624c9126d7fdb77a3c48 \
             --report "${{ runner.temp }}/cpp-sdk-doctest-report.html"
 
       - name: Stage report for upload
@@ -148,8 +146,6 @@ jobs:
             nix run github:logos-co/logos-doctest -- generate \
               "doctests/$spec.test.yaml" \
               --release-for logos-cpp-sdk=${{ steps.commit.outputs.sha }} \
-            --release-for logos-logoscore-cli=f1a6294d86aa46257b106d6f08c9bed9f940c3eb \
-            --release-for logos-module-builder=c849834b9d7b7eff1f94624c9126d7fdb77a3c48 \
               -o "/tmp/$spec.md"
             test -s "/tmp/$spec.md"
           done


### PR DESCRIPTION
The temporary `--release-for` pins for logos-logoscore-cli / logos-module-builder were added so the stacked qt-split branches could test against compatible cross-repo revs. The whole chain is merged now — both repos' masters carry the split, so the pins revert to default (latest release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)