### PR TITLE
fix: skip Qt wrapper hook for logos-cpp-generator on macOS Apple Silicon

### DIFF
--- a/nix/bin.nix
+++ b/nix/bin.nix
@@ -13,7 +13,8 @@ pkgs.stdenv.mkDerivation {
   
   # Skip default configure phase since we do it in buildPhase
   dontUseCmakeConfigure = true;
-  
+  dontWrapQtApps = true;
+
   buildPhase = ''
     runHook preBuild
     


### PR DESCRIPTION
The wrap-qt6-apps-no-gui-hook fixup step segfaults on aarch64-darwin (macOS Apple Silicon) 
due to a macOS SDK version mismatch in the Qt 6.9.2 derivation. The generator binary does 
not load Qt plugins at runtime so wrapping adds no value.

Fix: add `dontWrapQtApps = true` to `nix/bin.nix` to skip the hook entirely.

Tested on: macOS 14.6 / Apple Silicon (aarch64-darwin)
Related: [logos-co/logos-docs#307](https://github.com/logos-co/logos-docs/issues/307)