### PR TITLE
chore: bump logos-protocol (plaintext-args log fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782490644,
-        "narHash": "sha256-IRHFIBa/+a10tVNEexm6DDZ0JPF8YQgUbxWoNwIytt4=",
+        "lastModified": 1782842011,
+        "narHash": "sha256-2PZuDfaLe/CAs3W1vD0XVeR6gu18qG64jHimleelZns=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "d5d58e7e230768505c683150f651358612abd442",
+        "rev": "976bc7a9a0563e5513617f04a47e7f87f40faeaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Bumps the `logos-protocol` flake input to `976bc7a` ([logos-protocol#10](https://github.com/logos-co/logos-protocol/pull/10)), which stops `ModuleProxy::callRemoteMethod` from logging cross-module call **arguments** in plaintext (they routinely carry secrets — mnemonics, passwords, tokens). It now logs only `args.size()`, matching every other transport call site.

## Why this is a clean bump

`d5d58e7` (the currently-pinned protocol rev) is the **exact parent** of `976bc7a`, so this pulls in exactly one commit — the logging fix — and nothing else. Only `flake.lock` changes.

Part of a re-pin chain: protocol → {cpp-sdk, module-client} → rust-sdk → module-builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)