### PR TITLE
fix(codegen): bstr + composite-any type handling in cdylib + Qt wrappers

### DIFF
--- a/cpp-generator/experimental/lidl_gen_cdylib.cpp
+++ b/cpp-generator/experimental/lidl_gen_cdylib.cpp
@@ -39,6 +39,11 @@ bool typeSupported(const TypeExpr& te, bool isReturn)
     return false;
 }
 
+// Qt-free spelling of a LIDL type (defined below). Forward-declared so the
+// method-param decoder can spell composite `any` containers as their nlohmann
+// aliases instead of Qt containers in this Qt-free TU.
+QString lidlTypeToStdCdylib(const TypeExpr& te);
+
 // json arg expression -> std-typed C++ expression
 QString jsonArgToStd(const TypeExpr& te, const QString& expr)
 {
@@ -51,7 +56,11 @@ QString jsonArgToStd(const TypeExpr& te, const QString& expr)
         if (te.name == "bool")    return expr + ".get<bool>()";
     }
     if (te.kind == TypeExpr::Array && te.elements.size() == 1) {
-        const QString inner = lidlTypeToStd(te);
+        // Qt-free spelling: `[any]` must decode as LogosList, NOT QVariantList
+        // (lidlTypeToStd's Qt fallback), which is undeclared in this TU. Typed
+        // scalar arrays ([tstr]/[int]/…) are unaffected — Cdylib defers to the
+        // same std spelling for them.
+        const QString inner = lidlTypeToStdCdylib(te);
         return expr + ".get<" + inner + ">()";
     }
     return expr;

--- a/cpp-generator/legacy/generator_lib.cpp
+++ b/cpp-generator/legacy/generator_lib.cpp
@@ -60,6 +60,7 @@ QString toQVariantConversion(const QString& type, const QString& argExpr)
     if (type == "float") return argExpr + ".toFloat()";
     if (type == "QString") return argExpr + ".toString()";
     if (type == "QStringList") return argExpr + ".toStringList()";
+    if (type == "QByteArray") return argExpr + ".toByteArray()";
     if (type == "QJsonArray") return "qvariant_cast<QJsonArray>(" + argExpr + ")";
     if (type == "QVariantList") return argExpr + ".toList()";
     if (type == "QVariantMap") return argExpr + ".toMap()";
@@ -639,6 +640,11 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
             s << "    return _result.toString();\n";
         } else if (ret == "QStringList") {
             s << "    return _result.toStringList();\n";
+        } else if (ret == "QByteArray") {
+            // QVariant has no implicit conversion to QByteArray (unlike the
+            // scalar to* accessors), so a `bstr` return needs an explicit
+            // toByteArray() — matching the async path's qvariant_cast.
+            s << "    return _result.toByteArray();\n";
         } else if (ret == "QJsonArray") {
             s << "    return qvariant_cast<QJsonArray>(_result);\n";
         } else if (ret == "QVariantList") {


### PR DESCRIPTION
## What
Three code-generator type-handling gaps surfaced by a module exercising the full type surface (every method param/return + event param type):

1. **cdylib method-param decode** used `lidlTypeToStd()` for array params, which falls back to a Qt container (`QVariantList`) for `[any]` — undeclared in the Qt-free cdylib TU. Use the Qt-free `lidlTypeToStdCdylib()` so `[any]` decodes as `LogosList`.
2. The **Qt sync wrapper** had no `QByteArray` return case, emitting a bare `return _result;` for a `bstr` return (no implicit `QVariant` → `QByteArray`). Add `toByteArray()`.
3. The **Qt event-callback arg converter** had no `QByteArray` case, so a `bstr` event param was delivered via `.toString()`. Add `toByteArray()`.

Surfaced by the full_api test chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
