### PR TITLE
chore: bump logos-protocol to master (nested-bytes qvariantToNlohmann fix #23)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782842011,
-        "narHash": "sha256-2PZuDfaLe/CAs3W1vD0XVeR6gu18qG64jHimleelZns=",
+        "lastModified": 1784328026,
+        "narHash": "sha256-g+tR1Y/8b0yj28BWqybG8S9iDDTuwM8qs0FG8AuqoOU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "976bc7a9a0563e5513617f04a47e7f87f40faeaa",
+        "rev": "d5ba950313b3e4bb9d42d97af4c28df9083cfb41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Re-pins `logos-protocol` `976bc7a9` → master `d5ba950`, pulling in [logos-protocol#23](https://github.com/logos-co/logos-protocol/pull/23): `qvariantToNlohmann` now runs its container recursion before the `QJson` fallbacks, so a nested `QByteArray` keeps its `{"_bytes":…}` tag (and nested numerics keep their type) instead of being flattened. This fixes `bstr` method arguments to cdylib (Rust) modules, which were arriving as a plain string and decoding to an empty `Vec` (e.g. `echoBytes` returned `null`).

Also sweeps up the intervening merged protocol commits (#19 async `CallError` channel, #21 int-in-container preservation).

Lock-only change; builds clean against the new protocol locally. First hop of the propagation chain (protocol → cpp-sdk/module-client → qt-sdk/rust-sdk → liblogos/module-builder → hosts/test-modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)