### PR TITLE
chore: re-pin logos-protocol to master (LogosAPIConsumer handle cache)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784328026,
-        "narHash": "sha256-g+tR1Y/8b0yj28BWqybG8S9iDDTuwM8qs0FG8AuqoOU=",
+        "lastModified": 1784512868,
+        "narHash": "sha256-URbriX1AnFRgP7ZmgINPkTPnvCNNilzLxnIhGa2Ot6M=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "d5ba950313b3e4bb9d42d97af4c28df9083cfb41",
+        "rev": "664b43f18a9e752c0a80a422e5edfd99d76ffef6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `logos-protocol` `d5ba950 → 664b43f` to pick up logos-co/logos-protocol#24 — LogosAPIConsumer caches the remote-object handle per name (sync + async), avoiding a per-call QtRO replica acquire. Consumer-side, ABI-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)