### PR TITLE
feat: LogosTokenManagerContext + cdylib token-bridge wiring

### DIFF
--- a/cpp-generator/experimental/lidl_gen_cdylib.cpp
+++ b/cpp-generator/experimental/lidl_gen_cdylib.cpp
@@ -272,6 +272,7 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
     s << "#include \"logos_module_impl.h\"\n";
     s << "#include \"logos_protocol.h\"\n";
     s << "#include \"logos_module_context.h\"\n";
+    s << "#include \"logos_token_manager_context.h\"\n";
     s << "#include \"logos_result.h\"\n";
     s << "#include <nlohmann/json.hpp>\n";
     s << "#include <cstdlib>\n";
@@ -298,7 +299,13 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
     s << "std::mutex g_ctxMutex;\n";
     s << "bool g_ctxStored = false;\n";
     s << "std::string g_ctxPath, g_ctxId, g_ctxPersist;\n";
-    s << "std::atomic<bool> g_hookFired{false};\n\n";
+    s << "std::atomic<bool> g_hookFired{false};\n";
+    // Token bridge (opt-in; only wired for a LogosTokenManagerContext impl).
+    s << "logos_module_get_token_fn g_tokenGetFn = nullptr;\n";
+    s << "logos_module_inform_token_fn g_tokenInformFn = nullptr;\n";
+    s << "logos_module_free_fn g_tokenFreeFn = nullptr;\n";
+    s << "void* g_tokenUd = nullptr;\n";
+    s << "std::mutex g_tokenMutex;\n\n";
 
     s << "char* lidlStrdup(const std::string& str)\n{\n";
     s << "    char* out = static_cast<char*>(std::malloc(str.size() + 1));\n";
@@ -404,6 +411,37 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
     s << "        _logos_codegen_::maybeSetLogosModules(lidlImpl(), new LogosModules());\n";
     s << "    });\n}\n\n";
 
+    // -- token bridge wiring (only meaningful for a LogosTokenManagerContext
+    //    impl; the SFINAE no-op overload makes this inert for every other
+    //    module). Installs two std::function closures onto the impl that call
+    //    the host bridge function pointers (stored by logos_module_set_token_bridge)
+    //    at INVOCATION time — so the exact install order vs the bridge install
+    //    doesn't matter. Fired once from lidlTryFireContext, like the emit wiring.
+    s << "static void lidlEnsureTokenBridgeWiring()\n{\n";
+    s << "    static std::once_flag once;\n";
+    s << "    std::call_once(once, []() {\n";
+    s << "        _logos_codegen_::maybeSetTokenBridge(lidlImpl(),\n";
+    s << "            [](const std::string& name) -> std::string {\n";
+    s << "                logos_module_get_token_fn fn; logos_module_free_fn freeFn; void* ud;\n";
+    s << "                { std::lock_guard<std::mutex> lock(g_tokenMutex);\n";
+    s << "                  fn = g_tokenGetFn; freeFn = g_tokenFreeFn; ud = g_tokenUd; }\n";
+    s << "                if (!fn) return std::string();\n";
+    s << "                char* out = fn(ud, name.c_str());\n";
+    s << "                std::string result = out ? std::string(out) : std::string();\n";
+    s << "                if (out && freeFn) freeFn(ud, out);\n";
+    s << "                return result;\n";
+    s << "            },\n";
+    s << "            [](const std::string& target, const std::string& targetToken,\n";
+    s << "               const std::string& caller, const std::string& newToken) -> bool {\n";
+    s << "                logos_module_inform_token_fn fn; void* ud;\n";
+    s << "                { std::lock_guard<std::mutex> lock(g_tokenMutex);\n";
+    s << "                  fn = g_tokenInformFn; ud = g_tokenUd; }\n";
+    s << "                if (!fn) return false;\n";
+    s << "                return fn(ud, target.c_str(), targetToken.c_str(),\n";
+    s << "                          caller.c_str(), newToken.c_str()) == 0;\n";
+    s << "            });\n";
+    s << "    });\n}\n\n";
+
     // The context ready-latch: stamp the context + fire onContextReady ONCE,
     // as soon as the module is fully wired (context stored AND the emit
     // callback delivered) — at module load, before publication. Hosts that
@@ -412,6 +450,7 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
     s << "static void lidlTryFireContext(bool requireEmit)\n{\n";
     s << "    lidlEnsureEmitWiring();\n";
     s << "    lidlEnsureModulesWired();\n";
+    s << "    lidlEnsureTokenBridgeWiring();\n";
     s << "    if (g_hookFired.load(std::memory_order_acquire)) return;\n";
     s << "    std::string path, id, persist;\n";
     s << "    {\n";
@@ -501,6 +540,23 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
     s << "        g_emitUd = user_data;\n";
     s << "    }\n";
     s << "    lidlTryFireContext(true);\n";
+    s << "}\n\n";
+
+    s << "void logos_module_set_token_bridge(logos_module_get_token_fn get_token,\n";
+    s << "                                   logos_module_inform_token_fn inform_token,\n";
+    s << "                                   logos_module_free_fn free_fn,\n";
+    s << "                                   void* user_data)\n{\n";
+    s << "    {\n";
+    s << "        std::lock_guard<std::mutex> lock(g_tokenMutex);\n";
+    s << "        g_tokenGetFn = get_token;\n";
+    s << "        g_tokenInformFn = inform_token;\n";
+    s << "        g_tokenFreeFn = free_fn;\n";
+    s << "        g_tokenUd = user_data;\n";
+    s << "    }\n";
+    // Ensure the closures that read the pointers above are installed on the impl
+    // (idempotent; also fired on first dispatch). requireEmit=false so this never
+    // changes onContextReady timing.
+    s << "    lidlTryFireContext(false);\n";
     s << "}\n\n";
 
     s << "int logos_module_accept_token(const char* module_name, const char* token)\n{\n";

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -62,6 +62,7 @@ install(FILES
 
 install(FILES
     logos_module_context.h
+    logos_token_manager_context.h
     logos_json.h
     logos_result.h
     logos_lp_client.h

--- a/cpp/logos_token_manager_context.h
+++ b/cpp/logos_token_manager_context.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 #include "logos_module_context.h"
 
@@ -42,8 +43,11 @@ public:
 
 protected:
     // The host's stored auth token for `moduleName`, or "" when the module is
-    // unknown (never loaded / never issued a token). A non-empty result doubles
-    // as the "is this a known module identity?" check.
+    // unknown (never loaded / never issued a token) OR when the bridge is
+    // unwired (constructed outside a framework context, e.g. unit tests). A
+    // token-authority impl treats both the same way — fail closed — so it does
+    // not need to distinguish them. A non-empty result doubles as the "is this a
+    // known module identity?" check.
     std::string getToken(const std::string& moduleName) const {
         return m_getToken ? m_getToken(moduleName) : std::string();
     }

--- a/cpp/logos_token_manager_context.h
+++ b/cpp/logos_token_manager_context.h
@@ -1,0 +1,104 @@
+#ifndef LOGOS_TOKEN_MANAGER_CONTEXT_H
+#define LOGOS_TOKEN_MANAGER_CONTEXT_H
+
+#include <functional>
+#include <string>
+#include <type_traits>
+
+#include "logos_module_context.h"
+
+// ---------------------------------------------------------------------------
+// LogosTokenManagerContext — opt-in mixin for a TOKEN-AUTHORITY module.
+//
+// Only capability_module needs this. As a Qt-free universal (cdylib) module it
+// cannot touch the host's Qt TokenManager / LogosAPI directly, yet its job is
+// exactly to (a) read the host's stored auth tokens and (b) inform an ARBITRARY
+// target module of a caller's freshly-minted token. This context bridges both
+// through host-installed callbacks — the same injection mechanism
+// LogosModuleContext uses for the event callback (see
+// _logosCoreSetEmitEvent_): the generated cdylib provider, which runs in this
+// module's OWN subprocess and holds the LogosAPI, installs the two bridge
+// functions in onInit(); the impl calls the protected accessors below.
+//
+// The accessors no-op (return ""/false) when the impl is constructed outside a
+// framework-provisioned context (unit tests), matching LogosModuleContext's
+// empty-string fallbacks. Module code stays Qt-free: std::string only.
+// ---------------------------------------------------------------------------
+class LogosTokenManagerContext : public LogosModuleContext {
+public:
+    // Framework-only entry point — invoked by the generated provider's onInit
+    // once the LogosAPI is available. Leading/trailing underscore signals "do
+    // not call from user code", matching _logosCoreSetContext_ et al.
+    void _logosCoreSetTokenBridge_(
+        std::function<std::string(const std::string& moduleName)> getToken,
+        std::function<bool(const std::string& target,
+                           const std::string& targetToken,
+                           const std::string& caller,
+                           const std::string& newToken)> informModuleToken)
+    {
+        m_getToken = std::move(getToken);
+        m_informModuleToken = std::move(informModuleToken);
+    }
+
+protected:
+    // The host's stored auth token for `moduleName`, or "" when the module is
+    // unknown (never loaded / never issued a token). A non-empty result doubles
+    // as the "is this a known module identity?" check.
+    std::string getToken(const std::string& moduleName) const {
+        return m_getToken ? m_getToken(moduleName) : std::string();
+    }
+
+    // Tell `target` (authenticated with the host's `targetToken`) that `caller`
+    // may call it using `newToken`. Returns false when the bridge is unwired or
+    // the inform fails. The host implementation acquires the target's client on
+    // its owner thread and marshals the call, so this is safe to call from a
+    // concurrency:"multi" worker thread.
+    bool informModuleToken(const std::string& target,
+                           const std::string& targetToken,
+                           const std::string& caller,
+                           const std::string& newToken) const {
+        return m_informModuleToken
+            ? m_informModuleToken(target, targetToken, caller, newToken)
+            : false;
+    }
+
+private:
+    std::function<std::string(const std::string&)> m_getToken;
+    std::function<bool(const std::string&, const std::string&,
+                       const std::string&, const std::string&)> m_informModuleToken;
+};
+
+// ---------------------------------------------------------------------------
+// _logos_codegen_::maybeSetTokenBridge — codegen helper, do not call directly.
+// Same tag-dispatch trick as maybeSetContext / maybeSetEmitEvent: impls that
+// don't inherit LogosTokenManagerContext fall through to the no-op overload and
+// compile unchanged, so this addition is zero-cost for every other module.
+// ---------------------------------------------------------------------------
+namespace _logos_codegen_ {
+
+template<class T>
+inline auto maybeSetTokenBridge(
+    T& impl,
+    std::function<std::string(const std::string&)> getToken,
+    std::function<bool(const std::string&, const std::string&,
+                       const std::string&, const std::string&)> informModuleToken)
+    -> std::enable_if_t<std::is_base_of_v<LogosTokenManagerContext, T>>
+{
+    static_cast<LogosTokenManagerContext&>(impl)._logosCoreSetTokenBridge_(
+        std::move(getToken), std::move(informModuleToken));
+}
+
+template<class T>
+inline auto maybeSetTokenBridge(
+    T&,
+    std::function<std::string(const std::string&)>,
+    std::function<bool(const std::string&, const std::string&,
+                       const std::string&, const std::string&)>)
+    -> std::enable_if_t<!std::is_base_of_v<LogosTokenManagerContext, T>>
+{
+    // Module impl didn't opt into LogosTokenManagerContext; nothing to do.
+}
+
+} // namespace _logos_codegen_
+
+#endif // LOGOS_TOKEN_MANAGER_CONTEXT_H

--- a/nix/include.nix
+++ b/nix/include.nix
@@ -28,7 +28,7 @@ pkgs.stdenv.mkDerivation {
     # include/cpp/, a single TU would pull logos_result.h through two
     # distinct realpaths and #pragma once could not dedup them
     # (redefinition of StdLogosResult). Ship every std header in BOTH roots.
-    for file in logos_module_context.h logos_json.h logos_result.h logos_lp_client.h; do
+    for file in logos_module_context.h logos_token_manager_context.h logos_json.h logos_result.h logos_lp_client.h; do
       cp cpp/$file $out/include/cpp/
       cp cpp/$file $out/include/
     done


### PR DESCRIPTION
## What
The SDK half of the capability_module → Qt-free-universal change.

- **`LogosTokenManagerContext`** (new header, installed): an opt-in mixin, like `LogosModuleContext`, that gives a Qt-free impl two host services it otherwise can't reach — `getToken(name)` (read the host token store) and `informModuleToken(target, targetToken, caller, newToken)` (inform an arbitrary module). It stores the host bridge callbacks the generated provider installs via `_logosCoreSetTokenBridge_`, and no-ops when unwired (unit tests). A SFINAE `maybeSetTokenBridge` pair keeps it zero-cost for every impl that doesn't derive it.
- **cdylib generator** (`lidl_gen_cdylib.cpp`): emits the `logos_module_set_token_bridge` export + `lidlEnsureTokenBridgeWiring()`, which installs `std::function` closures onto the impl that call the stored host bridge pointers at invocation time (so install order doesn't matter).

## Depends on
logos-protocol#25 (the `logos_module_set_token_bridge` C ABI + typedefs). Merge that first.

## Consumed by
logos-qt-sdk (host-side bridge trampolines) and logos-capability-module (the universal rewrite).

## Test
Generator + lib build; capability_module builds against it and its unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)