### PR TITLE
chore: bump logos-protocol to master (rejection re-exchange #26)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784512868,
-        "narHash": "sha256-URbriX1AnFRgP7ZmgINPkTPnvCNNilzLxnIhGa2Ot6M=",
+        "lastModified": 1784668723,
+        "narHash": "sha256-bN4KcHm1wzWIvg0W/abV5SEruqdD75wOLjGkJTLjl5I=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "664b43f18a9e752c0a80a422e5edfd99d76ffef6",
+        "rev": "ef24bd70d930de8c54d98efd0ce21de939a616f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the `logos-protocol` pin to master (ef24bd7 — logos-protocol#26, rejection-driven token re-exchange + `unauthorized` sentinel). No source changes needed: cpp-sdk has no tests encoding the old reject→invalid-QVariant contract. Standalone `nix flake check`: **168/168 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)