### PR TITLE
chore: bump logos-protocol to the owner-thread destroy fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784668723,
-        "narHash": "sha256-bN4KcHm1wzWIvg0W/abV5SEruqdD75wOLjGkJTLjl5I=",
+        "lastModified": 1784753092,
+        "narHash": "sha256-cxl80GhIEd4U5R24ROJyDhj9zDpJ/oKCTd18oHWQREU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "ef24bd70d930de8c54d98efd0ce21de939a616f6",
+        "rev": "8ede8ece0817265c93297393febe6d908f8eb179",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Re-pins `logos-protocol` to **8ede8ec** — logos-co/logos-protocol#27, *destroy clients on their owner thread*.

## What it fixes

`lp_client_destroy` did a bare `delete` on the `LogosAPIClient` from whatever thread released the last handle share. That is not always the owner: any binding that parks a client share in a worker (a rust-sdk `EventSubscription` moved into a bridge thread, for one) runs the destroy there. Over QtRO that tears the transport's `QLocalSocket` notifiers down cross-thread, the fd closes under the owner's event dispatcher, and the module process takes SIGSEGV:

```
QSocketNotifier: Socket notifiers cannot be enabled or disabled from another thread   x2
QSocketNotifier: Invalid socket 19 with type Read, disabling...
FATAL: module 'chat_module' crashed (signal 11)
```

Every call path already marshalled with `logos::runOnOwnerThread`; destruction was the one that did not. It now defers via `deleteLater()`.

## Evidence

Reproduced end-to-end under `logoscore` with a pre-fix `chat_module`, then fixed — 3/3 runs each way, deterministic. A control arm (protocol master **without** #27) still crashes 3/3, isolating that single commit as the cause.

## Scope note

This repo's pin was one release behind the other SDKs, so the bump also crosses protocol#20 (group-shareable local sockets, stale-socket reaper, bind-failure detection). qt-sdk and module-builder were already at 6401e30 and cross only #27.

Checks green: `logos-cpp-sdk-tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
