### PR TITLE
chore: bump logos-protocol to the lp owner-thread fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784753092,
-        "narHash": "sha256-cxl80GhIEd4U5R24ROJyDhj9zDpJ/oKCTd18oHWQREU=",
+        "lastModified": 1785065460,
+        "narHash": "sha256-cp5Un0NBXwNoK/+atBLMl4NwCfDXzy0KMpyUOtK6pcc=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "8ede8ece0817265c93297393febe6d908f8eb179",
+        "rev": "ae2f7e1b5842d62836091c6dc0c903508806456e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up **logos-protocol `ae2f7e1`** ([#28](https://github.com/logos-co/logos-protocol/pull/28), merged): lp clients on a Qt-affine transport are constructed on the Qt main thread rather than on whichever thread happens to make the module's first outbound call.

Before it, a module whose first inter-module call came from a worker thread (an HTTP handler, a timer thread) bound its `QRemoteObjectNode` and socket to a thread with no event loop — every replica acquire then burned its full 20 s timeout and returned an empty result, silently. Found via [openmetrics-module#6](https://github.com/logos-co/openmetrics-module/pull/6): a single `GET /metrics` took 40 s and came back missing a module's payload; with the fix it takes 8 ms and is complete.

**Hygiene only for this repo.** `LpClient::ensure()` here still creates the client lazily — that is unchanged and correct; the fix is entirely inside the protocol's `lp_client_create`. Module builds take their protocol from `logos-module-builder`'s `follows`, so they do not depend on this pin. This just keeps cpp-sdk's own lock and its tests on the same protocol as the rest of the stack.

Lock-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)