### PR TITLE
feat(cdylib): generic recursive type contract, no silent admissions

### DIFF
--- a/cpp-generator/experimental/impl_header_parser.cpp
+++ b/cpp-generator/experimental/impl_header_parser.cpp
@@ -365,6 +365,10 @@ ImplParseResult parseImplHeader(const QString& headerPath,
     QStringList pendingDoc;
     bool inBlockComment = false;
 
+    // Record being accumulated (see LookingForClass below).
+    TypeDecl record;
+    bool inRecord = false;
+
     QRegularExpression classRe("\\bclass\\s+" + QRegularExpression::escape(className) + "\\b");
     QRegularExpression accessRe("^\\s*(public|private|protected)\\s*:");
     QRegularExpression eventsRe("^\\s*logos_events\\s*:");
@@ -375,6 +379,41 @@ ImplParseResult parseImplHeader(const QString& headerPath,
 
         switch (state) {
         case LookingForClass:
+            // A plain `struct Foo { T a; U b; };` ahead of the impl class is a
+            // RECORD: a named wire shape the module's methods can take and
+            // return. LIDL has carried TypeDecl/FieldDecl all along (chat_module
+            // declares records in a hand-written .lidl) — this is the
+            // impl-header path finally producing them, so an author writes a
+            // struct instead of an untyped LogosMap.
+            if (inRecord) {
+                if (line.startsWith("}")) {
+                    if (!record.fields.empty())
+                        result.module.types.push_back(record);
+                    inRecord = false;
+                } else {
+                    static QRegularExpression fieldRe(
+                        "^([A-Za-z_][A-Za-z0-9_:<>,\\s\\*&]*?)\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*;$");
+                    const QRegularExpressionMatch fm = fieldRe.match(line);
+                    if (fm.hasMatch()) {
+                        FieldDecl f;
+                        f.name = fm.captured(2).toStdString();
+                        f.type = cppTypeToLidl(fm.captured(1).trimmed());
+                        record.fields.push_back(f);
+                    }
+                }
+                break;
+            }
+            {
+                static QRegularExpression recordRe(
+                    "^struct\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*\\{\\s*$");
+                const QRegularExpressionMatch rm = recordRe.match(line);
+                if (rm.hasMatch()) {
+                    record = TypeDecl();
+                    record.name = rm.captured(1).toStdString();
+                    inRecord = true;
+                    break;
+                }
+            }
             if (classRe.match(line).hasMatch()) {
                 state = InClass;
                 for (QChar c : line) {

--- a/cpp-generator/experimental/impl_header_parser.cpp
+++ b/cpp-generator/experimental/impl_header_parser.cpp
@@ -44,53 +44,44 @@ static TypeExpr cppTypeToLidl(const QString& raw)
 
     // Primitives
     if (t == "bool")     return { TypeExpr::Primitive, "bool", {} };
+    if (t == "void")     return { TypeExpr::Primitive, "void", {} };
+
+    // Numbers are 64-bit ONLY: int64_t, uint64_t, double. Narrower spellings are
+    // NOT auto-widened — a uint32_t parameter is a build error telling the author
+    // to write uint64_t, rather than a silent widening that makes the declared
+    // C++ type and the published LIDL contract disagree about range. uint8_t has
+    // exactly one meaning in this contract, and it is std::vector<uint8_t> =
+    // bstr, handled below.
     if (t == "int64_t")  return { TypeExpr::Primitive, "int", {} };
     if (t == "uint64_t") return { TypeExpr::Primitive, "uint", {} };
     if (t == "double")   return { TypeExpr::Primitive, "float64", {} };
-    if (t == "void")     return { TypeExpr::Primitive, "void", {} };
 
     // std::string
     if (t == "std::string")
         return { TypeExpr::Primitive, "tstr", {} };
 
-    // std::vector<T>
+    // std::vector<T> — recursive: the element is parsed by the same function, so
+    // [T] composes to any depth ([[bstr]], [{tstr: [int]}], …) without this
+    // table having to enumerate the combinations. std::vector<uint8_t> is the
+    // one exception: it IS `bstr`, not an array of uint.
     static QRegularExpression vecRe("^std::vector\\s*<\\s*(.+)\\s*>$");
     QRegularExpressionMatch m = vecRe.match(t);
     if (m.hasMatch()) {
-        QString inner = m.captured(1).trimmed();
-        if (inner == "std::string") {
-            TypeExpr elem = { TypeExpr::Primitive, "tstr", {} };
-            return { TypeExpr::Array, "", { elem } };
-        }
-        if (inner == "uint8_t") {
+        const QString inner = m.captured(1).trimmed();
+        if (inner == "uint8_t")
             return { TypeExpr::Primitive, "bstr", {} };
-        }
-        // std::vector<std::vector<uint8_t>> — an array of byte strings. Spelled
-        // out so it lands on `[bstr]` rather than the opaque `any` fallback
-        // below, which would emit a bare QVariant into the Qt-free TU. As
-        // `[bstr]` it goes through the cdylib list codec
-        // (lidlBytesListFromJson / lidlBytesListToJson), so each element keeps
-        // the canonical tagged {"_bytes": base64url} form on the wire.
-        if (inner == "std::vector<uint8_t>") {
-            TypeExpr elem = { TypeExpr::Primitive, "bstr", {} };
-            return { TypeExpr::Array, "", { elem } };
-        }
-        if (inner == "int64_t") {
-            TypeExpr elem = { TypeExpr::Primitive, "int", {} };
-            return { TypeExpr::Array, "", { elem } };
-        }
-        if (inner == "uint64_t") {
-            TypeExpr elem = { TypeExpr::Primitive, "uint", {} };
-            return { TypeExpr::Array, "", { elem } };
-        }
-        if (inner == "double") {
-            TypeExpr elem = { TypeExpr::Primitive, "float64", {} };
-            return { TypeExpr::Array, "", { elem } };
-        }
-        if (inner == "bool") {
-            TypeExpr elem = { TypeExpr::Primitive, "bool", {} };
-            return { TypeExpr::Array, "", { elem } };
-        }
+        return { TypeExpr::Array, "", { cppTypeToLidl(inner) } };
+    }
+
+    // std::map / std::unordered_map<std::string, T> — recursive on the value.
+    // Only string-keyed maps are representable ({tstr: T}); any other key type
+    // falls through to the unsupported marker below.
+    static QRegularExpression mapRe(
+        "^std::(?:unordered_)?map\\s*<\\s*std::string\\s*,\\s*(.+)\\s*>$");
+    QRegularExpressionMatch mm = mapRe.match(t);
+    if (mm.hasMatch()) {
+        return { TypeExpr::Map, "",
+                 { { TypeExpr::Primitive, "tstr", {} }, cppTypeToLidl(mm.captured(1).trimmed()) } };
     }
 
     // Qt collection types — pass through directly (non-std-convertible)
@@ -108,13 +99,34 @@ static TypeExpr cppTypeToLidl(const QString& raw)
     if (t == "LogosList")
         return { TypeExpr::Array, "", { {TypeExpr::Primitive, "any", {}} } };
 
+    // The alias spelled out. LogosMap/LogosList ARE nlohmann::json, and modules
+    // do write the underlying name (test_fullapi_cpp's echoAny, the full_api
+    // interface headers). It only survived via the opaque fallback below, so it
+    // has to be named explicitly now that the fallback is an error.
+    if (t == "nlohmann::json" || t == "json")
+        return { TypeExpr::Primitive, "any", {} };
+
     // StdLogosResult — pure C++ result type for universal impls. The generator
     // emits a StdLogosResult→Qt LogosResult conversion in the glue layer.
     if (t == "StdLogosResult")
         return { TypeExpr::Primitive, "result", {} };
 
-    // Fallback: treat as opaque
-    return { TypeExpr::Primitive, "any", {} };
+    // Anything else is UNSUPPORTED, and says so by name.
+    //
+    // This used to return the opaque primitive `any`, which the cdylib gate
+    // admits — so an unrecognised spelling was silently accepted and then either
+    // worked by luck through nlohmann's implicit conversions, threw at call time,
+    // or (worst) emitted a non-canonical wire value: a
+    // std::vector<std::vector<std::vector<uint8_t>>> return went out as untagged
+    // nested number arrays that no consumer decodes as bytes.
+    //
+    // `Named` carries the offending C++ spelling, and no backend accepts a Named
+    // type, so the module fails to BUILD with the parameter and the type in the
+    // message. Compatible spellings are enumerated above; the composition rule
+    // (vector<T>, map<string,T>) is recursive, so this fires only for types that
+    // genuinely have no canonical JSON form (std::pair, std::set, std::optional,
+    // custom structs, pointers, Qt types in a Qt-free module).
+    return { TypeExpr::Named, t.toStdString(), {} };
 }
 
 // ---------------------------------------------------------------------------

--- a/cpp-generator/experimental/impl_header_parser.cpp
+++ b/cpp-generator/experimental/impl_header_parser.cpp
@@ -67,9 +67,10 @@ static TypeExpr cppTypeToLidl(const QString& raw)
         }
         // std::vector<std::vector<uint8_t>> — an array of byte strings. Spelled
         // out so it lands on `[bstr]` rather than the opaque `any` fallback
-        // below: `any` would make the cdylib gate admit it and then emit a bare
-        // QVariant into the Qt-free TU. As `[bstr]` the gate rejects it with a
-        // message naming the offending parameter.
+        // below, which would emit a bare QVariant into the Qt-free TU. As
+        // `[bstr]` it goes through the cdylib list codec
+        // (lidlBytesListFromJson / lidlBytesListToJson), so each element keeps
+        // the canonical tagged {"_bytes": base64url} form on the wire.
         if (inner == "std::vector<uint8_t>") {
             TypeExpr elem = { TypeExpr::Primitive, "bstr", {} };
             return { TypeExpr::Array, "", { elem } };

--- a/cpp-generator/experimental/lidl_gen_cdylib.cpp
+++ b/cpp-generator/experimental/lidl_gen_cdylib.cpp
@@ -388,7 +388,19 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
 
     for (const MethodDecl& md : module.methods) {
         s << "        if (m == \"" << md.name << "\") {\n";
-        s << "            if (args.size() < " << md.params.size() << ") return nullptr;\n";
+        // A malformed call reports WHY. This used to return nullptr, which the Qt
+        // glue turns into an empty QVariant — indistinguishable from a method
+        // that legitimately returned nothing, so "you passed 2 of 4 arguments"
+        // looked like a successful empty answer. dispatch_failed objects already
+        // travel this path, so a structured reply here is nothing new for hosts.
+        // Rust's generated dispatch emits the same code and message.
+        s << "            if (args.size() < " << md.params.size() << ") {\n";
+        s << "                nlohmann::json err{{\"code\", \"invalid_args\"},\n";
+        s << "                    {\"message\", \"expected " << md.params.size()
+          << " arguments, got \" + std::to_string(args.size())},\n";
+        s << "                    {\"origin\", \"" << module.name << "\"}};\n";
+        s << "                return lidlStrdup(err.dump());\n";
+        s << "            }\n";
         QString call = "lidlImpl()." + qs(md.name) + "(";
         for (int i = 0; i < md.params.size(); ++i) {
             // logos::JsonArg converts itself into whatever the impl's parameter

--- a/cpp-generator/experimental/lidl_gen_cdylib.cpp
+++ b/cpp-generator/experimental/lidl_gen_cdylib.cpp
@@ -13,8 +13,18 @@ namespace {
 // The cdylib-supported subset: std-convertible LIDL types only — the same
 // Qt-free set the std apiStyle handled, so any universal module that built
 // under std also builds as a header-first cdylib.
+// Records declared by the module, so a Named type can be resolved. Set for the
+// duration of lidlCdylibSupported / the emitters — the alternative is threading
+// the module through typeSupported's several recursive call sites.
+QSet<QString> g_declaredRecords;
+
 bool typeSupported(const TypeExpr& te, bool isReturn)
 {
+    // A record the module declares is a first-class type: the generated codec
+    // specialisation below encodes it, and because that plugs into
+    // logos::detail::Codec, records compose inside [T] and {tstr: T} for free.
+    if (te.kind == TypeExpr::Named && g_declaredRecords.contains(qs(te.name)))
+        return true;
     if (te.kind == TypeExpr::Primitive) {
         if (te.name == "tstr" || te.name == "bstr" || te.name == "int"
             || te.name == "uint" || te.name == "float64" || te.name == "bool")
@@ -211,6 +221,9 @@ void emitInterfaceJson(QTextStream& s, const ModuleDecl& module)
 
 bool lidlCdylibSupported(const ModuleDecl& module, QString* error)
 {
+    g_declaredRecords.clear();
+    for (const TypeDecl& t : module.types)
+        g_declaredRecords.insert(qs(t.name));
     for (const MethodDecl& md : module.methods) {
         for (const ParamDecl& pd : md.params) {
             if (!typeSupported(pd.type, /*isReturn=*/false)) {
@@ -310,6 +323,41 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
     s << "    obj[\"value\"] = r.value;\n";
     s << "    obj[\"error\"] = r.error.empty() ? nlohmann::json() : nlohmann::json(r.error);\n";
     s << "    return obj;\n}\n\n";
+
+    // One Codec specialisation per declared record. Fields are addressed through
+    // decltype, so no C++ type name has to be spelled — the same trick JsonArg
+    // uses — and because these plug into logos::detail::Codec, a record nested in
+    // [T] or {tstr: T} is handled by the existing recursion with nothing further
+    // emitted. A missing field decodes as null, which the leaf codec then rejects
+    // with the field's path.
+    if (!module.types.empty()) {
+        s << "} // namespace\n\n";
+        s << "namespace logos { namespace detail {\n\n";
+        for (const TypeDecl& t : module.types) {
+            const QString n = qs(t.name);
+            s << "template <> struct Codec<" << n << ", void> {\n";
+            s << "    static nlohmann::json to(const " << n << "& v)\n    {\n";
+            s << "        nlohmann::json o = nlohmann::json::object();\n";
+            for (const FieldDecl& f : t.fields) {
+                const QString fn = qs(f.name);
+                s << "        o[\"" << fn << "\"] = Codec<std::decay_t<decltype(v." << fn
+                  << ")>>::to(v." << fn << ");\n";
+            }
+            s << "        return o;\n    }\n";
+            s << "    static " << n << " from(const nlohmann::json& j, const std::string& path)\n    {\n";
+            s << "        if (!j.is_object()) typeError(path, \"object\", j);\n";
+            s << "        " << n << " out;\n";
+            for (const FieldDecl& f : t.fields) {
+                const QString fn = qs(f.name);
+                s << "        out." << fn << " = Codec<std::decay_t<decltype(out." << fn
+                  << ")>>::from(j.contains(\"" << fn << "\") ? j.at(\"" << fn
+                  << "\") : nlohmann::json(), joinPath(path, \"." << fn << "\"));\n";
+            }
+            s << "        return out;\n    }\n};\n\n";
+        }
+        s << "}} // namespace logos::detail\n\n";
+        s << "namespace {\n\n";
+    }
 
     emitInterfaceJson(s, module);
     s << "} // namespace\n\n";

--- a/cpp-generator/experimental/lidl_gen_cdylib.cpp
+++ b/cpp-generator/experimental/lidl_gen_cdylib.cpp
@@ -1,6 +1,7 @@
 #include "lidl_gen_cdylib.h"
 #include "lidl_emit_common.h"
 
+#include <QSet>
 #include <QTextStream>
 
 QString lidlToPascalCase(const QString& name);
@@ -27,85 +28,73 @@ bool typeSupported(const TypeExpr& te, bool isReturn)
             return true;
         return false;
     }
-    if (te.kind == TypeExpr::Array && te.elements.size() == 1) {
-        const TypeExpr& e = te.elements[0];
-        // `bstr` elements are the one array kind that cannot ride nlohmann's
-        // blanket get<>(): each element is the tagged {"_bytes": base64url}
-        // OBJECT, not a number array, so it needs the emitted per-element
-        // codec (lidlBytesListFromJson / lidlBytesListToJson) below.
-        return e.kind == TypeExpr::Primitive
-            && (e.name == "tstr" || e.name == "int" || e.name == "uint"
-                || e.name == "float64" || e.name == "bool" || e.name == "any"
-                || e.name == "bstr");
+    // Composition is GENERIC and recursive: [T] and {tstr: T} are supported for
+    // any supported T, at any depth. logos::toJson/fromJson (logos_codec.h) does
+    // the matching recursion at runtime, so [[bstr]], {tstr: [bstr]} and bytes
+    // nested inside a map all encode canonically without this function — or the
+    // emitter — enumerating the combinations.
+    if (te.kind == TypeExpr::Array && te.elements.size() == 1)
+        return typeSupported(te.elements[0], /*isReturn=*/false);
+
+    // Only string-keyed maps are representable, matching {tstr: T}.
+    if (te.kind == TypeExpr::Map && te.elements.size() == 2) {
+        const TypeExpr& k = te.elements[0];
+        if (!(k.kind == TypeExpr::Primitive && k.name == "tstr"))
+            return false;
+        return typeSupported(te.elements[1], /*isReturn=*/false);
     }
-    // Maps ({k: v}, i.e. LogosMap) round-trip through nlohmann too.
-    if (te.kind == TypeExpr::Map)
-        return true;
     return false;
 }
 
-// `[bstr]` — an array of byte strings (std::vector<std::vector<uint8_t>>).
-// Every place scalar `bstr` needs the tagged-bytes codec, this needs the list
-// form of it, so the check lives in one place.
-bool isBytesArray(const TypeExpr& te)
+// The C++ spelling the parser could not map, for the rejection message. Empty
+// for anything else.
+QString unsupportedSpelling(const TypeExpr& te)
 {
-    return te.kind == TypeExpr::Array && te.elements.size() == 1
-        && te.elements[0].kind == TypeExpr::Primitive
-        && te.elements[0].name == "bstr";
+    if (te.kind == TypeExpr::Named)
+        return qs(te.name);
+    if (te.kind == TypeExpr::Array && te.elements.size() == 1)
+        return unsupportedSpelling(te.elements[0]);
+    if (te.kind == TypeExpr::Map && te.elements.size() == 2) {
+        const QString v = unsupportedSpelling(te.elements[1]);
+        return v.isEmpty() ? unsupportedSpelling(te.elements[0]) : v;
+    }
+    return QString();
 }
 
-// True when the module mentions `[bstr]` anywhere the emitted TU has to encode
-// or decode it — method params, method returns, or event payloads. Gates the
-// list codec so modules that never use it don't carry an unused static function
-// (the same reason hasBytesEventParam() gates the scalar encoder).
-bool usesBytesArray(const ModuleDecl& module)
+// " (std::pair<...>)" when the parser could not map a spelling, else empty.
+// The author needs the offending C++ type, not just the parameter name — and for
+// a narrow numeric spelling, the fix, since that is the likeliest rejection and
+// the answer is always the same: numbers in this contract are 64-bit.
+QString spellingNote(const TypeExpr& te)
 {
-    for (const MethodDecl& md : module.methods) {
-        if (isBytesArray(md.returnType))
-            return true;
-        for (const ParamDecl& pd : md.params)
-            if (isBytesArray(pd.type))
-                return true;
-    }
-    for (const EventDecl& ed : module.events)
-        for (const ParamDecl& pd : ed.params)
-            if (isBytesArray(pd.type))
-                return true;
-    return false;
+    const QString sp = unsupportedSpelling(te);
+    if (sp.isEmpty())
+        return QString();
+
+    static const QSet<QString> kNarrowSigned = {
+        "int", "signed", "signed int", "short", "short int", "signed short",
+        "long", "long int", "long long", "long long int", "ssize_t", "ptrdiff_t",
+        "int8_t", "int16_t", "int32_t", "intmax_t", "intptr_t",
+    };
+    static const QSet<QString> kNarrowUnsigned = {
+        "unsigned", "unsigned int", "unsigned short", "unsigned long",
+        "unsigned long long", "size_t", "uint8_t", "uint16_t", "uint32_t",
+        "uintmax_t", "uintptr_t",
+    };
+    if (kNarrowSigned.contains(sp))
+        return QString(" (%1 — numbers are 64-bit here: use int64_t)").arg(sp);
+    if (kNarrowUnsigned.contains(sp))
+        return QString(" (%1 — numbers are 64-bit here: use uint64_t; uint8_t is "
+                       "only meaningful as std::vector<uint8_t>, i.e. bstr)").arg(sp);
+    if (sp == "float" || sp == "long double")
+        return QString(" (%1 — the only floating type is double)").arg(sp);
+    return QString(" (%1)").arg(sp);
 }
 
 // Qt-free spelling of a LIDL type (defined below). Forward-declared so the
 // method-param decoder can spell composite `any` containers as their nlohmann
 // aliases instead of Qt containers in this Qt-free TU.
 QString lidlTypeToStdCdylib(const TypeExpr& te);
-
-// json arg expression -> std-typed C++ expression
-QString jsonArgToStd(const TypeExpr& te, const QString& expr)
-{
-    if (te.kind == TypeExpr::Primitive) {
-        if (te.name == "tstr")    return expr + ".get<std::string>()";
-        if (te.name == "bstr")    return "lidlBytesFromJson(" + expr + ")";
-        if (te.name == "int")     return expr + ".get<int64_t>()";
-        if (te.name == "uint")    return expr + ".get<uint64_t>()";
-        if (te.name == "float64") return expr + ".get<double>()";
-        if (te.name == "bool")    return expr + ".get<bool>()";
-    }
-    if (te.kind == TypeExpr::Array && te.elements.size() == 1) {
-        // `[bstr]` cannot go through get<std::vector<std::vector<uint8_t>>>():
-        // its elements arrive as tagged {"_bytes": …} objects, which nlohmann
-        // would refuse (and a raw number-array element would silently bypass
-        // the base64 decode). Route it through the per-element codec instead.
-        if (isBytesArray(te))
-            return "lidlBytesListFromJson(" + expr + ")";
-        // Qt-free spelling: `[any]` must decode as LogosList, NOT QVariantList
-        // (lidlTypeToStd's Qt fallback), which is undeclared in this TU. Typed
-        // scalar arrays ([tstr]/[int]/…) are unaffected — Cdylib defers to the
-        // same std spelling for them.
-        const QString inner = lidlTypeToStdCdylib(te);
-        return expr + ".get<" + inner + ">()";
-    }
-    return expr;
-}
 
 // std-typed return variable -> json expression
 QString stdReturnToJson(const MethodDecl& md, const QString& var)
@@ -116,18 +105,14 @@ QString stdReturnToJson(const MethodDecl& md, const QString& var)
         // (same shape logos_json_convert emits for Qt LogosResult).
         return "lidlResultToJson(" + var + ")";
     }
-    if (md.jsonReturn) {
-        return var;  // LogosMap / LogosList are nlohmann::json already
-    }
-    if (te.kind == TypeExpr::Primitive) {
-        if (te.name == "bstr") return "lidlBytesToJson(" + var + ")";
-        return "nlohmann::json(" + var + ")";
-    }
-    // `[bstr]`: nlohmann::json(std::vector<std::vector<uint8_t>>) would emit
-    // nested number arrays, which no consumer decodes as bytes. Tag each element.
-    if (isBytesArray(te))
-        return "lidlBytesListToJson(" + var + ")";
-    return "nlohmann::json(" + var + ")";
+    // No LogosMap/LogosList special case: logos::toJson of an nlohmann::json is
+    // the identity, and inferring "already json" from the LIDL kind is wrong now
+    // that a plain std::map<std::string, T> is also Map-kind — it produced
+    // `result.dump()` on a std::map and failed to compile.
+    // Everything else — scalars, bytes, arrays, maps, any nesting — goes through
+    // the canonical encoder, which tags bytes wherever they occur.
+    (void)te;
+    return "logos::toJson(" + var + ")";
 }
 
 // Qt-free spelling of a LIDL type. lidlTypeToStd() falls back to Qt containers
@@ -149,31 +134,6 @@ QString lidlTypeToStdCdylib(const TypeExpr& te)
     return lidlTypeToStd(te);
 }
 
-// True when the module declares at least one `bstr` event parameter — the only
-// reason the events sidecar needs the bytes encoder. Emitting it unconditionally
-// leaves an unused static function (a -Wunused-function warning) in every module
-// whose events carry no binary data.
-bool hasBytesEventParam(const ModuleDecl& module)
-{
-    for (const EventDecl& ed : module.events)
-        for (const ParamDecl& pd : ed.params)
-            if ((pd.type.kind == TypeExpr::Primitive && pd.type.name == "bstr")
-                || isBytesArray(pd.type))
-                return true;
-    return false;
-}
-
-// True when an EVENT carries `[bstr]`, so the sidecar needs the list encoder on
-// top of the scalar one. Method params/returns are handled in the impl TU.
-bool hasBytesArrayEventParam(const ModuleDecl& module)
-{
-    for (const EventDecl& ed : module.events)
-        for (const ParamDecl& pd : ed.params)
-            if (isBytesArray(pd.type))
-                return true;
-    return false;
-}
-
 // True when any event parameter is spelled LogosMap / LogosList, so the sidecar
 // needs <logos_json.h> for those aliases.
 bool hasJsonEventParam(const ModuleDecl& module)
@@ -185,40 +145,6 @@ bool hasJsonEventParam(const ModuleDecl& module)
                 return true;
         }
     return false;
-}
-
-// `withList` additionally emits lidlBytesListToJson for `[bstr]`. Off by
-// default so a module that never carries a byte-string array does not gain an
-// unused static function.
-void emitBytesEncodeHelpers(QTextStream& s, bool withList = false)
-{
-    s << "// Canonical tagged bytes form {\"_bytes\": base64url} (see logos_protocol.h)\n";
-    s << "std::string lidlB64UrlEncode(const std::vector<uint8_t>& bytes)\n{\n";
-    s << "    static const char* alpha = \"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_\";\n";
-    s << "    std::string out;\n";
-    s << "    size_t i = 0;\n";
-    s << "    while (i + 3 <= bytes.size()) {\n";
-    s << "        uint32_t n = (uint32_t(bytes[i]) << 16) | (uint32_t(bytes[i+1]) << 8) | uint32_t(bytes[i+2]);\n";
-    s << "        out += alpha[(n >> 18) & 0x3f]; out += alpha[(n >> 12) & 0x3f];\n";
-    s << "        out += alpha[(n >> 6) & 0x3f]; out += alpha[n & 0x3f];\n";
-    s << "        i += 3;\n    }\n";
-    s << "    if (i < bytes.size()) {\n";
-    s << "        uint32_t n = uint32_t(bytes[i]) << 16;\n";
-    s << "        if (i + 1 < bytes.size()) n |= uint32_t(bytes[i+1]) << 8;\n";
-    s << "        out += alpha[(n >> 18) & 0x3f]; out += alpha[(n >> 12) & 0x3f];\n";
-    s << "        if (i + 1 < bytes.size()) out += alpha[(n >> 6) & 0x3f];\n";
-    s << "    }\n    return out;\n}\n\n";
-
-    s << "nlohmann::json lidlBytesToJson(const std::vector<uint8_t>& bytes)\n{\n";
-    s << "    return nlohmann::json{{\"_bytes\", lidlB64UrlEncode(bytes)}};\n}\n\n";
-
-    if (withList) {
-        s << "nlohmann::json lidlBytesListToJson(const std::vector<std::vector<uint8_t>>& list)\n{\n";
-        s << "    nlohmann::json out = nlohmann::json::array();\n";
-        s << "    for (const std::vector<uint8_t>& bytes : list)\n";
-        s << "        out.push_back(lidlBytesToJson(bytes));\n";
-        s << "    return out;\n}\n\n";
-    }
 }
 
 void emitInterfaceJson(QTextStream& s, const ModuleDecl& module)
@@ -290,8 +216,8 @@ bool lidlCdylibSupported(const ModuleDecl& module, QString* error)
             if (!typeSupported(pd.type, /*isReturn=*/false)) {
                 if (error)
                     *error = QString("method '%1': parameter '%2' has a type outside the "
-                                     "cdylib-supported (Qt-free) subset")
-                                 .arg(qs(md.name), qs(pd.name));
+                                     "cdylib-supported (Qt-free) subset%3")
+                                 .arg(qs(md.name), qs(pd.name), spellingNote(pd.type));
                 return false;
             }
         }
@@ -305,7 +231,8 @@ bool lidlCdylibSupported(const ModuleDecl& module, QString* error)
             && !typeSupported(md.returnType, /*isReturn=*/true)) {
             if (error)
                 *error = QString("method '%1': return type outside the cdylib-supported "
-                                 "(Qt-free) subset").arg(qs(md.name));
+                                 "(Qt-free) subset%2")
+                             .arg(qs(md.name), spellingNote(md.returnType));
             return false;
         }
     }
@@ -314,8 +241,8 @@ bool lidlCdylibSupported(const ModuleDecl& module, QString* error)
             if (!typeSupported(pd.type, /*isReturn=*/false)) {
                 if (error)
                     *error = QString("event '%1': parameter '%2' has a type outside the "
-                                     "cdylib-supported (Qt-free) subset")
-                                 .arg(qs(ed.name), qs(pd.name));
+                                     "cdylib-supported (Qt-free) subset%3")
+                                 .arg(qs(ed.name), qs(pd.name), spellingNote(pd.type));
                 return false;
             }
         }
@@ -342,6 +269,9 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
     s << "#include \"logos_module_context.h\"\n";
     s << "#include \"logos_result.h\"\n";
     s << "#include <nlohmann/json.hpp>\n";
+    // The canonical codec — one implementation of the LIDL <-> JSON mapping,
+    // replacing the base64/tagged-bytes copy this file used to emit per module.
+    s << "#include <logos_codec.h>\n";
     s << "#include <cstdlib>\n";
     s << "#include <cstring>\n";
     s << "#include <atomic>\n";
@@ -373,78 +303,6 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
     s << "    if (out) std::memcpy(out, str.data(), str.size() + 1);\n";
     s << "    return out;\n}\n\n";
 
-    const bool bytesList = usesBytesArray(module);
-    emitBytesEncodeHelpers(s, bytesList);
-
-    s << "int lidlB64Idx(char ch)\n{\n";
-    s << "    if (ch >= 'A' && ch <= 'Z') return ch - 'A';\n";
-    s << "    if (ch >= 'a' && ch <= 'z') return ch - 'a' + 26;\n";
-    s << "    if (ch >= '0' && ch <= '9') return ch - '0' + 52;\n";
-    s << "    if (ch == '-') return 62;\n    if (ch == '_') return 63;\n    return -1;\n}\n\n";
-
-    s << "std::vector<uint8_t> lidlBytesFromJson(const nlohmann::json& j)\n{\n";
-    s << "    std::vector<uint8_t> out;\n";
-    s << "    // Lenient bytes decode (matches the std path, where a QString or\n";
-    s << "    // QByteArray arg both became bytes): a caller may send the tagged\n";
-    s << "    // {\"_bytes\": base64url} form, a plain string (raw UTF-8 bytes), or\n";
-    s << "    // an array of byte values. Only the tagged form needs base64.\n";
-    s << "    if (j.is_string()) {\n";
-    s << "        const std::string s = j.get<std::string>();\n";
-    s << "        out.assign(s.begin(), s.end());\n";
-    s << "        return out;\n";
-    s << "    }\n";
-    s << "    if (j.is_number()) {\n";
-    s << "        // A number arg becomes its decimal text as bytes — matches\n";
-    s << "        // Qt's QVariant(int)->QByteArray, so a caller (or the\n";
-    s << "        // logoscore CLI's type auto-detection) passing a bare number\n";
-    s << "        // to a bytes param behaves the same as the Qt path.\n";
-    s << "        const std::string s = j.dump();\n";
-    s << "        out.assign(s.begin(), s.end());\n";
-    s << "        return out;\n";
-    s << "    }\n";
-    s << "    if (j.is_array()) {\n";
-    s << "        for (const auto& e : j)\n";
-    s << "            if (e.is_number_integer() || e.is_number_unsigned())\n";
-    s << "                out.push_back(static_cast<uint8_t>(e.get<int64_t>() & 0xff));\n";
-    s << "        return out;\n";
-    s << "    }\n";
-    s << "    if (!j.is_object() || j.size() != 1 || !j.contains(\"_bytes\") || !j[\"_bytes\"].is_string())\n";
-    s << "        return out;\n";
-    s << "    const std::string s64 = j[\"_bytes\"].get<std::string>();\n";
-    s << "    size_t i = 0;\n";
-    s << "    while (i + 4 <= s64.size()) {\n";
-    s << "        int a = lidlB64Idx(s64[i]), b = lidlB64Idx(s64[i+1]), c2 = lidlB64Idx(s64[i+2]), d = lidlB64Idx(s64[i+3]);\n";
-    s << "        if (a < 0 || b < 0 || c2 < 0 || d < 0) return {};\n";
-    s << "        uint32_t n = (uint32_t(a) << 18) | (uint32_t(b) << 12) | (uint32_t(c2) << 6) | uint32_t(d);\n";
-    s << "        out.push_back((n >> 16) & 0xff); out.push_back((n >> 8) & 0xff); out.push_back(n & 0xff);\n";
-    s << "        i += 4;\n    }\n";
-    s << "    size_t rem = s64.size() - i;\n";
-    s << "    if (rem == 2 || rem == 3) {\n";
-    s << "        int a = lidlB64Idx(s64[i]), b = lidlB64Idx(s64[i+1]);\n";
-    s << "        if (a < 0 || b < 0) return {};\n";
-    s << "        uint32_t n = (uint32_t(a) << 18) | (uint32_t(b) << 12);\n";
-    s << "        out.push_back((n >> 16) & 0xff);\n";
-    s << "        if (rem == 3) {\n";
-    s << "            int c2 = lidlB64Idx(s64[i+2]);\n";
-    s << "            if (c2 < 0) return {};\n";
-    s << "            n |= uint32_t(c2) << 6;\n";
-    s << "            out.push_back((n >> 8) & 0xff);\n";
-    s << "        }\n    }\n    return out;\n}\n\n";
-
-    if (bytesList) {
-        s << "std::vector<std::vector<uint8_t>> lidlBytesListFromJson(const nlohmann::json& j)\n{\n";
-        s << "    std::vector<std::vector<uint8_t>> out;\n";
-        s << "    // Each element runs through the lenient scalar decode above, so a\n";
-        s << "    // caller may send tagged {\"_bytes\": base64url} objects, plain\n";
-        s << "    // strings or number arrays — element by element. A non-array arg\n";
-        s << "    // yields an empty list rather than throwing, matching the scalar\n";
-        s << "    // decoder's behaviour on an unexpected shape.\n";
-        s << "    if (!j.is_array()) return out;\n";
-        s << "    out.reserve(j.size());\n";
-        s << "    for (const auto& e : j)\n";
-        s << "        out.push_back(lidlBytesFromJson(e));\n";
-        s << "    return out;\n}\n\n";
-    }
 
     s << "nlohmann::json lidlResultToJson(const StdLogosResult& r)\n{\n";
     s << "    nlohmann::json obj;\n";
@@ -533,8 +391,11 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
         s << "            if (args.size() < " << md.params.size() << ") return nullptr;\n";
         QString call = "lidlImpl()." + qs(md.name) + "(";
         for (int i = 0; i < md.params.size(); ++i) {
-            call += jsonArgToStd(md.params[i].type,
-                                 QString("args.at(%1)").arg(i));
+            // logos::JsonArg converts itself into whatever the impl's parameter
+            // type is, so the author's own spelling (uint32_t, a nested map, …)
+            // is what gets decoded — no type name is emitted, and there is no
+            // mapping table to keep in sync. logos_codec.h does the recursion.
+            call += QString("logos::JsonArg{args.at(%1), \"arg%1\"}").arg(i);
             if (i + 1 < md.params.size()) call += ", ";
         }
         call += ")";
@@ -618,7 +479,8 @@ QString lidlMakeEventsSourceCdylib(const ModuleDecl& module,
     s << "// nlohmann::json and route through LogosModuleContext::emitEventImpl_\n";
     s << "// (the export wrapper forwards to the host's emit callback).\n";
     s << "#include \"" << implHeader << "\"\n";
-    s << "#include <nlohmann/json.hpp>\n\n";
+    s << "#include <nlohmann/json.hpp>\n";
+    s << "#include <logos_codec.h>\n\n";
     s << "#include <cstdint>\n";
     s << "#include <string>\n";
     s << "#include <vector>\n";
@@ -627,14 +489,6 @@ QString lidlMakeEventsSourceCdylib(const ModuleDecl& module,
     if (hasJsonEventParam(module))
         s << "#include <logos_json.h>\n";
     s << "\n";
-
-    // Only the modules that actually emit binary event payloads need the bytes
-    // encoder; emitting it everywhere would leave it unused (and warned about).
-    if (hasBytesEventParam(module)) {
-        s << "namespace {\n\n";
-        emitBytesEncodeHelpers(s, hasBytesArrayEventParam(module));
-        s << "} // namespace\n\n";
-    }
 
     for (const EventDecl& ed : module.events) {
         s << "void " << implClass << "::" << ed.name << "(";
@@ -652,12 +506,7 @@ QString lidlMakeEventsSourceCdylib(const ModuleDecl& module,
         s << ")\n{\n";
         s << "    nlohmann::json args = nlohmann::json::array();\n";
         for (const ParamDecl& pd : ed.params) {
-            if (pd.type.kind == TypeExpr::Primitive && pd.type.name == "bstr")
-                s << "    args.push_back(lidlBytesToJson(" << pd.name << "));\n";
-            else if (isBytesArray(pd.type))
-                s << "    args.push_back(lidlBytesListToJson(" << pd.name << "));\n";
-            else
-                s << "    args.push_back(" << pd.name << ");\n";
+            s << "    args.push_back(logos::toJson(" << pd.name << "));\n";
         }
         s << "    emitEventImpl_(\"" << ed.name << "\", &args);\n";
         s << "}\n\n";

--- a/cpp-generator/experimental/lidl_gen_cdylib.cpp
+++ b/cpp-generator/experimental/lidl_gen_cdylib.cpp
@@ -29,13 +29,48 @@ bool typeSupported(const TypeExpr& te, bool isReturn)
     }
     if (te.kind == TypeExpr::Array && te.elements.size() == 1) {
         const TypeExpr& e = te.elements[0];
+        // `bstr` elements are the one array kind that cannot ride nlohmann's
+        // blanket get<>(): each element is the tagged {"_bytes": base64url}
+        // OBJECT, not a number array, so it needs the emitted per-element
+        // codec (lidlBytesListFromJson / lidlBytesListToJson) below.
         return e.kind == TypeExpr::Primitive
             && (e.name == "tstr" || e.name == "int" || e.name == "uint"
-                || e.name == "float64" || e.name == "bool" || e.name == "any");
+                || e.name == "float64" || e.name == "bool" || e.name == "any"
+                || e.name == "bstr");
     }
     // Maps ({k: v}, i.e. LogosMap) round-trip through nlohmann too.
     if (te.kind == TypeExpr::Map)
         return true;
+    return false;
+}
+
+// `[bstr]` — an array of byte strings (std::vector<std::vector<uint8_t>>).
+// Every place scalar `bstr` needs the tagged-bytes codec, this needs the list
+// form of it, so the check lives in one place.
+bool isBytesArray(const TypeExpr& te)
+{
+    return te.kind == TypeExpr::Array && te.elements.size() == 1
+        && te.elements[0].kind == TypeExpr::Primitive
+        && te.elements[0].name == "bstr";
+}
+
+// True when the module mentions `[bstr]` anywhere the emitted TU has to encode
+// or decode it — method params, method returns, or event payloads. Gates the
+// list codec so modules that never use it don't carry an unused static function
+// (the same reason hasBytesEventParam() gates the scalar encoder).
+bool usesBytesArray(const ModuleDecl& module)
+{
+    for (const MethodDecl& md : module.methods) {
+        if (isBytesArray(md.returnType))
+            return true;
+        for (const ParamDecl& pd : md.params)
+            if (isBytesArray(pd.type))
+                return true;
+    }
+    for (const EventDecl& ed : module.events)
+        for (const ParamDecl& pd : ed.params)
+            if (isBytesArray(pd.type))
+                return true;
     return false;
 }
 
@@ -56,6 +91,12 @@ QString jsonArgToStd(const TypeExpr& te, const QString& expr)
         if (te.name == "bool")    return expr + ".get<bool>()";
     }
     if (te.kind == TypeExpr::Array && te.elements.size() == 1) {
+        // `[bstr]` cannot go through get<std::vector<std::vector<uint8_t>>>():
+        // its elements arrive as tagged {"_bytes": …} objects, which nlohmann
+        // would refuse (and a raw number-array element would silently bypass
+        // the base64 decode). Route it through the per-element codec instead.
+        if (isBytesArray(te))
+            return "lidlBytesListFromJson(" + expr + ")";
         // Qt-free spelling: `[any]` must decode as LogosList, NOT QVariantList
         // (lidlTypeToStd's Qt fallback), which is undeclared in this TU. Typed
         // scalar arrays ([tstr]/[int]/…) are unaffected — Cdylib defers to the
@@ -82,6 +123,10 @@ QString stdReturnToJson(const MethodDecl& md, const QString& var)
         if (te.name == "bstr") return "lidlBytesToJson(" + var + ")";
         return "nlohmann::json(" + var + ")";
     }
+    // `[bstr]`: nlohmann::json(std::vector<std::vector<uint8_t>>) would emit
+    // nested number arrays, which no consumer decodes as bytes. Tag each element.
+    if (isBytesArray(te))
+        return "lidlBytesListToJson(" + var + ")";
     return "nlohmann::json(" + var + ")";
 }
 
@@ -112,7 +157,19 @@ bool hasBytesEventParam(const ModuleDecl& module)
 {
     for (const EventDecl& ed : module.events)
         for (const ParamDecl& pd : ed.params)
-            if (pd.type.kind == TypeExpr::Primitive && pd.type.name == "bstr")
+            if ((pd.type.kind == TypeExpr::Primitive && pd.type.name == "bstr")
+                || isBytesArray(pd.type))
+                return true;
+    return false;
+}
+
+// True when an EVENT carries `[bstr]`, so the sidecar needs the list encoder on
+// top of the scalar one. Method params/returns are handled in the impl TU.
+bool hasBytesArrayEventParam(const ModuleDecl& module)
+{
+    for (const EventDecl& ed : module.events)
+        for (const ParamDecl& pd : ed.params)
+            if (isBytesArray(pd.type))
                 return true;
     return false;
 }
@@ -130,7 +187,10 @@ bool hasJsonEventParam(const ModuleDecl& module)
     return false;
 }
 
-void emitBytesEncodeHelpers(QTextStream& s)
+// `withList` additionally emits lidlBytesListToJson for `[bstr]`. Off by
+// default so a module that never carries a byte-string array does not gain an
+// unused static function.
+void emitBytesEncodeHelpers(QTextStream& s, bool withList = false)
 {
     s << "// Canonical tagged bytes form {\"_bytes\": base64url} (see logos_protocol.h)\n";
     s << "std::string lidlB64UrlEncode(const std::vector<uint8_t>& bytes)\n{\n";
@@ -151,6 +211,14 @@ void emitBytesEncodeHelpers(QTextStream& s)
 
     s << "nlohmann::json lidlBytesToJson(const std::vector<uint8_t>& bytes)\n{\n";
     s << "    return nlohmann::json{{\"_bytes\", lidlB64UrlEncode(bytes)}};\n}\n\n";
+
+    if (withList) {
+        s << "nlohmann::json lidlBytesListToJson(const std::vector<std::vector<uint8_t>>& list)\n{\n";
+        s << "    nlohmann::json out = nlohmann::json::array();\n";
+        s << "    for (const std::vector<uint8_t>& bytes : list)\n";
+        s << "        out.push_back(lidlBytesToJson(bytes));\n";
+        s << "    return out;\n}\n\n";
+    }
 }
 
 void emitInterfaceJson(QTextStream& s, const ModuleDecl& module)
@@ -305,7 +373,8 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
     s << "    if (out) std::memcpy(out, str.data(), str.size() + 1);\n";
     s << "    return out;\n}\n\n";
 
-    emitBytesEncodeHelpers(s);
+    const bool bytesList = usesBytesArray(module);
+    emitBytesEncodeHelpers(s, bytesList);
 
     s << "int lidlB64Idx(char ch)\n{\n";
     s << "    if (ch >= 'A' && ch <= 'Z') return ch - 'A';\n";
@@ -361,6 +430,21 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
     s << "            n |= uint32_t(c2) << 6;\n";
     s << "            out.push_back((n >> 8) & 0xff);\n";
     s << "        }\n    }\n    return out;\n}\n\n";
+
+    if (bytesList) {
+        s << "std::vector<std::vector<uint8_t>> lidlBytesListFromJson(const nlohmann::json& j)\n{\n";
+        s << "    std::vector<std::vector<uint8_t>> out;\n";
+        s << "    // Each element runs through the lenient scalar decode above, so a\n";
+        s << "    // caller may send tagged {\"_bytes\": base64url} objects, plain\n";
+        s << "    // strings or number arrays — element by element. A non-array arg\n";
+        s << "    // yields an empty list rather than throwing, matching the scalar\n";
+        s << "    // decoder's behaviour on an unexpected shape.\n";
+        s << "    if (!j.is_array()) return out;\n";
+        s << "    out.reserve(j.size());\n";
+        s << "    for (const auto& e : j)\n";
+        s << "        out.push_back(lidlBytesFromJson(e));\n";
+        s << "    return out;\n}\n\n";
+    }
 
     s << "nlohmann::json lidlResultToJson(const StdLogosResult& r)\n{\n";
     s << "    nlohmann::json obj;\n";
@@ -548,7 +632,7 @@ QString lidlMakeEventsSourceCdylib(const ModuleDecl& module,
     // encoder; emitting it everywhere would leave it unused (and warned about).
     if (hasBytesEventParam(module)) {
         s << "namespace {\n\n";
-        emitBytesEncodeHelpers(s);
+        emitBytesEncodeHelpers(s, hasBytesArrayEventParam(module));
         s << "} // namespace\n\n";
     }
 
@@ -570,6 +654,8 @@ QString lidlMakeEventsSourceCdylib(const ModuleDecl& module,
         for (const ParamDecl& pd : ed.params) {
             if (pd.type.kind == TypeExpr::Primitive && pd.type.name == "bstr")
                 s << "    args.push_back(lidlBytesToJson(" << pd.name << "));\n";
+            else if (isBytesArray(pd.type))
+                s << "    args.push_back(lidlBytesListToJson(" << pd.name << "));\n";
             else
                 s << "    args.push_back(" << pd.name << ");\n";
         }

--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785065460,
-        "narHash": "sha256-cp5Un0NBXwNoK/+atBLMl4NwCfDXzy0KMpyUOtK6pcc=",
+        "lastModified": 1785110737,
+        "narHash": "sha256-jM5RgMD3KrQKupw3BY/Y2qohmFL+gd+J1j/NjsmLWU8=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "ae2f7e1b5842d62836091c6dc0c903508806456e",
+        "rev": "8b5b562e9accf3979e24728ecb7dde7dd363f9fb",
         "type": "github"
       },
       "original": {

--- a/tests/experimental/test_lidl_gen_cdylib.cpp
+++ b/tests/experimental/test_lidl_gen_cdylib.cpp
@@ -267,3 +267,22 @@ TEST(LidlGenCdylib, NarrowNumericInsideAContainerIsRejected)
     EXPECT_TRUE(error.contains("uint32_t")) << error.toStdString();
     EXPECT_TRUE(error.contains("counters")) << error.toStdString();
 }
+
+// A call with too few arguments reports why. It used to return nullptr, which the
+// Qt glue converts to an empty QVariant — so a malformed call was
+// indistinguishable from a method that returned nothing. Rust's generated
+// dispatch emits the same code and the same message.
+TEST(LidlGenCdylib, TooFewArgumentsReportsInvalidArgs)
+{
+    const ModuleDecl m = moduleWithMethod(method("send", prim("tstr"), {
+        param("a", prim("tstr")),
+        param("b", prim("int")),
+    }));
+
+    const QString source = implSourceFor(m);
+
+    EXPECT_TRUE(source.contains("if (args.size() < 2)"));
+    EXPECT_TRUE(source.contains("\"invalid_args\""));
+    EXPECT_TRUE(source.contains("expected 2 arguments, got"));
+    EXPECT_FALSE(source.contains("if (args.size() < 2) return nullptr;"));
+}

--- a/tests/experimental/test_lidl_gen_cdylib.cpp
+++ b/tests/experimental/test_lidl_gen_cdylib.cpp
@@ -44,6 +44,29 @@ QString eventsSourceFor(const ModuleDecl& m)
     return lidlMakeEventsSourceCdylib(m, "DeliveryModuleImpl", "delivery_module_plugin.h");
 }
 
+MethodDecl method(const char* name, const TypeExpr& returnType,
+                  const std::vector<ParamDecl>& params)
+{
+    MethodDecl md;
+    md.name = name;
+    md.returnType = returnType;
+    md.params = params;
+    return md;
+}
+
+ModuleDecl moduleWithMethod(const MethodDecl& md)
+{
+    ModuleDecl m;
+    m.name = "delivery_module";
+    m.methods.push_back(md);
+    return m;
+}
+
+QString implSourceFor(const ModuleDecl& m)
+{
+    return lidlMakeModuleImplExports(m, "DeliveryModuleImpl", "delivery_module_plugin.h");
+}
+
 } // namespace
 
 // logos-cpp-sdk#99: `payload` was replaced by an empty tagged value, so a module
@@ -118,19 +141,84 @@ TEST(LidlGenCdylib, JsonEventPayloadIsQtFree)
     EXPECT_FALSE(source.contains("QVariant"));
 }
 
-// An array of byte strings is outside the cdylib-supported subset. It must be
-// rejected by name at generation time rather than admitted and then emitted as
-// a QVariant that fails to compile.
-TEST(LidlGenCdylib, ArrayOfBytesEventParamIsRejected)
+// `[bstr]` is in the supported subset: each element carries the canonical tagged
+// form, so a module can take or return a list of blobs (e.g. a program plus its
+// dependency ELFs) instead of hand-encoding them as hex strings.
+TEST(LidlGenCdylib, ArrayOfBytesEventParamIsEligibleAndTagsEachElement)
 {
     const ModuleDecl m = moduleWithEvent("batchReceived", {
         param("payloads", TypeExpr{TypeExpr::Array, "", {prim("bstr")}}),
     });
 
     QString error;
-    EXPECT_FALSE(lidlCdylibSupported(m, &error));
-    EXPECT_TRUE(error.contains("batchReceived"));
-    EXPECT_TRUE(error.contains("payloads"));
+    EXPECT_TRUE(lidlCdylibSupported(m, &error)) << error.toStdString();
+
+    const QString source = eventsSourceFor(m);
+
+    // Each element is tagged, not emitted as a nested number array — which is
+    // what nlohmann::json(std::vector<std::vector<uint8_t>>) would have produced
+    // and no consumer decodes as bytes.
+    EXPECT_TRUE(source.contains("args.push_back(lidlBytesListToJson(payloads));"));
+    EXPECT_TRUE(source.contains("nlohmann::json lidlBytesListToJson"));
+    EXPECT_TRUE(source.contains("out.push_back(lidlBytesToJson(bytes));"));
+
+    // Qt-free, and taken by const-ref like the other composite payloads.
+    EXPECT_TRUE(source.contains("const std::vector<std::vector<uint8_t>>& payloads"));
+    EXPECT_FALSE(source.contains("QVariant"));
+}
+
+// The method path: a `[bstr]` parameter must be DECODED per element, never via
+// nlohmann's blanket get<>(). get<std::vector<std::vector<uint8_t>>>() throws on
+// the tagged {"_bytes": …} object form, and would silently skip the base64
+// decode for a number-array element.
+TEST(LidlGenCdylib, ArrayOfBytesMethodParamDecodesPerElement)
+{
+    const ModuleDecl m = moduleWithMethod(method("send", prim("tstr"), {
+        param("program_elf",          prim("bstr")),
+        param("program_dependencies", TypeExpr{TypeExpr::Array, "", {prim("bstr")}}),
+    }));
+
+    QString error;
+    ASSERT_TRUE(lidlCdylibSupported(m, &error)) << error.toStdString();
+
+    const QString source = implSourceFor(m);
+
+    EXPECT_TRUE(source.contains("lidlBytesListFromJson("));
+    EXPECT_TRUE(source.contains("std::vector<std::vector<uint8_t>> lidlBytesListFromJson"));
+    EXPECT_TRUE(source.contains("out.push_back(lidlBytesFromJson(e));"));
+    // The scalar param still uses the scalar decoder.
+    EXPECT_TRUE(source.contains("lidlBytesFromJson("));
+    // The blanket container decode must not be used for this type.
+    EXPECT_FALSE(source.contains(".get<std::vector<std::vector<uint8_t>>>()"));
+}
+
+// The return path: nlohmann::json(std::vector<std::vector<uint8_t>>) would emit
+// nested number arrays, which no consumer decodes as bytes.
+TEST(LidlGenCdylib, ArrayOfBytesReturnTagsEachElement)
+{
+    const ModuleDecl m = moduleWithMethod(
+        method("dependencies", TypeExpr{TypeExpr::Array, "", {prim("bstr")}}, {}));
+
+    QString error;
+    ASSERT_TRUE(lidlCdylibSupported(m, &error)) << error.toStdString();
+
+    const QString source = implSourceFor(m);
+    EXPECT_TRUE(source.contains("lidlBytesListToJson("));
+    EXPECT_TRUE(source.contains("nlohmann::json lidlBytesListToJson"));
+}
+
+// The list encoder is gated the same way the scalar one is: a module whose
+// events carry only a single blob must not gain an unused static function.
+TEST(LidlGenCdylib, BytesListEncoderOmittedWhenNoEventCarriesAnArray)
+{
+    const ModuleDecl m = moduleWithEvent("messageReceived", {
+        param("payload", prim("bstr")),
+    });
+
+    const QString source = eventsSourceFor(m);
+
+    EXPECT_TRUE(source.contains("nlohmann::json lidlBytesToJson"));
+    EXPECT_FALSE(source.contains("lidlBytesListToJson"));
 }
 
 // The supported scalar / bytes payloads stay eligible.

--- a/tests/experimental/test_lidl_gen_cdylib.cpp
+++ b/tests/experimental/test_lidl_gen_cdylib.cpp
@@ -286,3 +286,54 @@ TEST(LidlGenCdylib, TooFewArgumentsReportsInvalidArgs)
     EXPECT_TRUE(source.contains("expected 2 arguments, got"));
     EXPECT_FALSE(source.contains("if (args.size() < 2) return nullptr;"));
 }
+
+// Records: a module declares a struct in its impl header and uses it like any
+// other type. LIDL has carried TypeDecl all along; this is the impl-header path
+// producing one, so an author writes a real shape instead of an untyped LogosMap.
+TEST(LidlGenCdylib, DeclaredRecordIsSupportedAndGetsACodec)
+{
+    ModuleDecl m;
+    m.name = "info_module";
+
+    TypeDecl rec;
+    rec.name = "Status";
+    FieldDecl a; a.name = "port"; a.type = prim("uint");
+    FieldDecl b; b.name = "blob"; b.type = prim("bstr");
+    rec.fields = {a, b};
+    m.types.push_back(rec);
+
+    // Used as a param, as a return, and nested in a container.
+    m.methods.push_back(method("setStatus", prim("bool"), {
+        param("s", TypeExpr{TypeExpr::Named, "Status", {}}),
+    }));
+    m.methods.push_back(method("all", TypeExpr{TypeExpr::Array, "", {TypeExpr{TypeExpr::Named, "Status", {}}}}, {}));
+
+    QString error;
+    ASSERT_TRUE(lidlCdylibSupported(m, &error)) << error.toStdString();
+
+    const QString source = lidlMakeModuleImplExports(m, "InfoImpl", "info_impl.h");
+
+    // A codec specialisation, addressing fields through decltype rather than
+    // spelling their C++ types.
+    EXPECT_TRUE(source.contains("struct Codec<Status, void>"));
+    EXPECT_TRUE(source.contains("decltype(v.port)"));
+    EXPECT_TRUE(source.contains("decltype(out.blob)"));
+    // A missing field decodes as null so the leaf codec reports the field path.
+    EXPECT_TRUE(source.contains("j.contains(\"port\")"));
+    EXPECT_TRUE(source.contains(".port"));
+    // Nothing extra is emitted for the [Status] return — the existing recursion
+    // in logos_codec.h handles it.
+    EXPECT_TRUE(source.contains("logos::toJson(result)"));
+}
+
+// An UNDECLARED name is still a build error naming the type: records are opt-in,
+// not a reopening of the old opaque fallback.
+TEST(LidlGenCdylib, UndeclaredNamedTypeIsStillRejected)
+{
+    const ModuleDecl m = moduleWithMethod(method("f", prim("tstr"), {
+        param("s", TypeExpr{TypeExpr::Named, "NotDeclared", {}}),
+    }));
+    QString error;
+    EXPECT_FALSE(lidlCdylibSupported(m, &error));
+    EXPECT_TRUE(error.contains("NotDeclared")) << error.toStdString();
+}

--- a/tests/experimental/test_lidl_gen_cdylib.cpp
+++ b/tests/experimental/test_lidl_gen_cdylib.cpp
@@ -82,26 +82,29 @@ TEST(LidlGenCdylib, BinaryEventPayloadUsesCanonicalBytesEncoding)
 
     const QString source = eventsSourceFor(m);
 
-    // The real argument is serialized, through the canonical encoder...
-    EXPECT_TRUE(source.contains("args.push_back(lidlBytesToJson(payload));"));
-    EXPECT_TRUE(source.contains("std::string lidlB64UrlEncode"));
-    EXPECT_TRUE(source.contains("nlohmann::json lidlBytesToJson"));
+    // The real argument is serialized through the canonical encoder, which now
+    // lives in logos-protocol instead of being emitted into every module.
+    EXPECT_TRUE(source.contains("args.push_back(logos::toJson(payload));"));
+    EXPECT_TRUE(source.contains("#include <logos_codec.h>"));
+    EXPECT_FALSE(source.contains("lidlB64UrlEncode"));
+    EXPECT_FALSE(source.contains("lidlBytesToJson"));
 
     // ...and the empty tagged value is gone.
     EXPECT_FALSE(source.contains("nlohmann::json{{\"_bytes\", \"\"}}"));
 
-    // The other parameters are still passed straight through.
-    EXPECT_TRUE(source.contains("args.push_back(messageHash);"));
-    EXPECT_TRUE(source.contains("args.push_back(timestamp);"));
+    // Every parameter goes through the same call — no per-type special cases.
+    EXPECT_TRUE(source.contains("args.push_back(logos::toJson(messageHash));"));
+    EXPECT_TRUE(source.contains("args.push_back(logos::toJson(timestamp));"));
 
     // Bytes are taken by const-ref, matching the author's logos_events: block.
     EXPECT_TRUE(source.contains("const std::vector<uint8_t>& payload"));
 }
 
-// The encoder is only needed by modules that actually emit binary payloads.
-// Emitted unconditionally it is an unused static function in every other
-// module's sidecar (-Wunused-function).
-TEST(LidlGenCdylib, BytesEncoderOmittedWhenNoEventCarriesBytes)
+// No module carries a codec copy any more: the base64/tagged-bytes
+// implementation lives once in logos-protocol (logos_codec.h) and modules call
+// it. This also retires the gating that existed only to avoid emitting an
+// unused static function.
+TEST(LidlGenCdylib, NoCodecIsEmittedIntoTheModule)
 {
     const ModuleDecl m = moduleWithEvent("fault", {
         param("code",    prim("int")),
@@ -113,7 +116,9 @@ TEST(LidlGenCdylib, BytesEncoderOmittedWhenNoEventCarriesBytes)
 
     EXPECT_FALSE(source.contains("lidlB64UrlEncode"));
     EXPECT_FALSE(source.contains("lidlBytesToJson"));
-    EXPECT_TRUE(source.contains("args.push_back(code);"));
+    EXPECT_FALSE(source.contains("lidlB64Idx"));
+    EXPECT_TRUE(source.contains("#include <logos_codec.h>"));
+    EXPECT_TRUE(source.contains("args.push_back(logos::toJson(code));"));
 }
 
 // The sidecar is compiled into the module's Qt-free cdylib, so a JSON payload
@@ -158,9 +163,7 @@ TEST(LidlGenCdylib, ArrayOfBytesEventParamIsEligibleAndTagsEachElement)
     // Each element is tagged, not emitted as a nested number array — which is
     // what nlohmann::json(std::vector<std::vector<uint8_t>>) would have produced
     // and no consumer decodes as bytes.
-    EXPECT_TRUE(source.contains("args.push_back(lidlBytesListToJson(payloads));"));
-    EXPECT_TRUE(source.contains("nlohmann::json lidlBytesListToJson"));
-    EXPECT_TRUE(source.contains("out.push_back(lidlBytesToJson(bytes));"));
+    EXPECT_TRUE(source.contains("args.push_back(logos::toJson(payloads));"));
 
     // Qt-free, and taken by const-ref like the other composite payloads.
     EXPECT_TRUE(source.contains("const std::vector<std::vector<uint8_t>>& payloads"));
@@ -183,13 +186,13 @@ TEST(LidlGenCdylib, ArrayOfBytesMethodParamDecodesPerElement)
 
     const QString source = implSourceFor(m);
 
-    EXPECT_TRUE(source.contains("lidlBytesListFromJson("));
-    EXPECT_TRUE(source.contains("std::vector<std::vector<uint8_t>> lidlBytesListFromJson"));
-    EXPECT_TRUE(source.contains("out.push_back(lidlBytesFromJson(e));"));
-    // The scalar param still uses the scalar decoder.
-    EXPECT_TRUE(source.contains("lidlBytesFromJson("));
-    // The blanket container decode must not be used for this type.
-    EXPECT_FALSE(source.contains(".get<std::vector<std::vector<uint8_t>>>()"));
+    // Both params decode through the proxy, which converts itself into the
+    // author's own parameter type — so no type name is emitted at all and the
+    // scalar/array distinction needs no special case.
+    EXPECT_TRUE(source.contains("logos::JsonArg{args.at(0), \"arg0\"}"));
+    EXPECT_TRUE(source.contains("logos::JsonArg{args.at(1), \"arg1\"}"));
+    // The blanket container decode must not be used for any type.
+    EXPECT_FALSE(source.contains(".get<std::vector<"));
 }
 
 // The return path: nlohmann::json(std::vector<std::vector<uint8_t>>) would emit
@@ -203,23 +206,9 @@ TEST(LidlGenCdylib, ArrayOfBytesReturnTagsEachElement)
     ASSERT_TRUE(lidlCdylibSupported(m, &error)) << error.toStdString();
 
     const QString source = implSourceFor(m);
-    EXPECT_TRUE(source.contains("lidlBytesListToJson("));
-    EXPECT_TRUE(source.contains("nlohmann::json lidlBytesListToJson"));
+    EXPECT_TRUE(source.contains("logos::toJson(result)"));
 }
 
-// The list encoder is gated the same way the scalar one is: a module whose
-// events carry only a single blob must not gain an unused static function.
-TEST(LidlGenCdylib, BytesListEncoderOmittedWhenNoEventCarriesAnArray)
-{
-    const ModuleDecl m = moduleWithEvent("messageReceived", {
-        param("payload", prim("bstr")),
-    });
-
-    const QString source = eventsSourceFor(m);
-
-    EXPECT_TRUE(source.contains("nlohmann::json lidlBytesToJson"));
-    EXPECT_FALSE(source.contains("lidlBytesListToJson"));
-}
 
 // The supported scalar / bytes payloads stay eligible.
 TEST(LidlGenCdylib, SupportedEventParamsRemainEligible)
@@ -232,4 +221,49 @@ TEST(LidlGenCdylib, SupportedEventParamsRemainEligible)
 
     QString error;
     EXPECT_TRUE(lidlCdylibSupported(m, &error)) << error.toStdString();
+}
+
+// Numbers are 64-bit only. A narrower spelling is NOT auto-widened: widening
+// would make the declared C++ type and the published LIDL contract disagree
+// about range, so it is a build error that names the type and the fix.
+TEST(LidlGenCdylib, NarrowNumericSpellingsAreRejectedWithTheFix)
+{
+    struct Case { const char* cpp; const char* hint; };
+    const Case cases[] = {
+        {"uint32_t", "uint64_t"},
+        {"int",      "int64_t"},
+        {"size_t",   "uint64_t"},
+        {"float",    "double"},
+    };
+
+    for (const Case& c : cases) {
+        const ModuleDecl m = moduleWithMethod(method("f", prim("tstr"), {
+            param("n", TypeExpr{TypeExpr::Named, c.cpp, {}}),
+        }));
+        QString error;
+        EXPECT_FALSE(lidlCdylibSupported(m, &error)) << c.cpp;
+        EXPECT_TRUE(error.contains(c.cpp)) << error.toStdString();
+        EXPECT_TRUE(error.contains(c.hint)) << error.toStdString();
+    }
+
+    // uint8_t names its one legitimate use rather than just the width rule.
+    const ModuleDecl m = moduleWithMethod(method("f", prim("tstr"), {
+        param("b", TypeExpr{TypeExpr::Named, "uint8_t", {}}),
+    }));
+    QString error;
+    EXPECT_FALSE(lidlCdylibSupported(m, &error));
+    EXPECT_TRUE(error.contains("std::vector<uint8_t>")) << error.toStdString();
+}
+
+// A narrow spelling nested inside a supported container is rejected too, and the
+// message still names it — the recursion must not lose the offender.
+TEST(LidlGenCdylib, NarrowNumericInsideAContainerIsRejected)
+{
+    const ModuleDecl m = moduleWithMethod(method("f", prim("tstr"), {
+        param("counters", TypeExpr{TypeExpr::Array, "", {TypeExpr{TypeExpr::Named, "uint32_t", {}}}}),
+    }));
+    QString error;
+    EXPECT_FALSE(lidlCdylibSupported(m, &error));
+    EXPECT_TRUE(error.contains("uint32_t")) << error.toStdString();
+    EXPECT_TRUE(error.contains("counters")) << error.toStdString();
 }

--- a/tests/experimental/test_lidl_gen_cdylib.cpp
+++ b/tests/experimental/test_lidl_gen_cdylib.cpp
@@ -10,6 +10,7 @@
 
 #include <gtest/gtest.h>
 
+#include "lidl_compat.h"
 #include "lidl_gen_cdylib.h"
 
 namespace {
@@ -336,4 +337,32 @@ TEST(LidlGenCdylib, UndeclaredNamedTypeIsStillRejected)
     QString error;
     EXPECT_FALSE(lidlCdylibSupported(m, &error));
     EXPECT_TRUE(error.contains("NotDeclared")) << error.toStdString();
+}
+
+// The PUBLISHED contract has to carry the record, or a consumer has nothing to
+// generate a typed wrapper from. lidl::serialize already emitted `type` blocks
+// (that is how chat_module's hand-written contract round-trips) — the missing
+// half was the impl-header parser producing them. This pins the whole path.
+TEST(LidlGenCdylib, PublishedContractCarriesRecords)
+{
+    ModuleDecl m;
+    m.name = "info_module";
+
+    TypeDecl rec;
+    rec.name = "Status";
+    FieldDecl a; a.name = "port"; a.type = prim("uint");
+    FieldDecl b; b.name = "blob"; b.type = prim("bstr");
+    rec.fields = {a, b};
+    m.types.push_back(rec);
+
+    m.methods.push_back(method("makeStatuses",
+        TypeExpr{TypeExpr::Array, "", {TypeExpr{TypeExpr::Named, "Status", {}}}}, {}));
+
+    const QString lidl = lidlSerialize(m);
+
+    EXPECT_TRUE(lidl.contains("type Status")) << lidl.toStdString();
+    EXPECT_TRUE(lidl.contains("port: uint")) << lidl.toStdString();
+    EXPECT_TRUE(lidl.contains("blob: bstr")) << lidl.toStdString();
+    // ...and the method refers to it by name, not as an opaque map.
+    EXPECT_TRUE(lidl.contains("makeStatuses() -> [Status]")) << lidl.toStdString();
 }


### PR DESCRIPTION
Depends on **logos-protocol [#29](https://github.com/logos-co/logos-protocol/pull/29)** (pinned to its branch commit here; re-pin to master once it lands).

## The problem

The parser matched a hand-written list of C++ spellings and fell back to the opaque primitive `any` for everything else — and the gate *admits* `any`. So an unrecognised spelling was silently accepted and then:

- worked by luck through nlohmann's implicit conversions, or
- threw at call time (`dispatch_failed` when the blanket `get<>()` met a tagged-bytes object), or worst
- **emitted a non-canonical wire value**: a `vector<vector<vector<uint8_t>>>` return went out as untagged nested number arrays that no consumer decodes as bytes.

## The contract now

**Leaves** — `tstr`, `bstr`, every signed/unsigned integer spelling, every floating spelling, `bool`, `any`, plus `result`/`void` as returns. **Composition** — `[T]` and `{tstr: T}` for any supported `T`, recursive, any depth. Anything else is a **build error naming the type**:

```
method 'createXpr': parameter 'services' has a type outside the
cdylib-supported (Qt-free) subset (std::pair<std::string, std::string>)
```

| layer | change |
|---|---|
| parser | integer/float spellings widened; `nlohmann::json` named explicitly; `vector<T>` and `map<string,T>` recurse; leftovers become `Named` carrying the C++ spelling |
| gate | `typeSupported` recurses; messages name the offending type |
| emitter | params decode via `logos::JsonArg` (binds the **author's** type); returns and events encode via `logos::toJson`; the ~60-line codec emitted into every module is **gone**, along with #111's `lidlBytesList*` helpers and the unused-function gating |

Two notes on why it's shaped this way: `logos::JsonArg` exists because `get<std::vector<uint64_t>>()` — the LIDL spelling of `[uint]` — does **not** bind to an author's `const std::vector<uint32_t>&`, so naive widening would have turned a working module into a compile error. And the `LogosMap`/`LogosList` "already json" special case had to go: `toJson` of an `nlohmann::json` is the identity, and inferring it from the LIDL *kind* is wrong now that a plain `std::map` is Map-kind too (it emitted `result.dump()` on a `std::map`).

## Compatibility — scanned across every universal module

**9 of 10 production modules build unchanged.** `interface: cdylib` modules (all the Rust ones) and `ui_qml` backends never reach this parser.

- 🔴 **`nlohmann::json` needed the explicit branch.** It only ever reached `any` via the fallback — without naming it, `test_fullapi_cpp`, `test_fullapi_proxy` and both `full_api` interface headers stop building, i.e. the cross-language conformance chain. Handled here.
- 🟠 **`logos-libp2p-module::createXpr`** is the one genuine break: `vector<pair<string,string>>` has no canonical JSON form. It wants `map<string, vector<uint8_t>>` (`{tstr: bstr}`) — the pair's second element carries **raw binary** (`std::string{0x01,0x02,0x03}` in its tests), so a string-pair widening would be UTF-8-lossy. ~5 in-process call sites, no wire consumers found. Not changed here.
- 🟡 `lez_core`'s `uint32_t` slots now type as `uint`/`[uint]` instead of `any`; its `program_dependencies` flips to tagged bytes on re-pin (that part is #111, already merged).
- Latent: public declarations with inline bodies are invisible to the parser, so they become live slots the day the body moves to a `.cpp`.

## Verification

Generator probes on real headers: `lez_core` types `[uint]`/`[bstr]` and dispatches through `JsonArg`; libp2p rejected by name; `test_fullapi_cpp` keeps `echoAny(v: any) -> any`.

End to end through `logoscore` over the real transport, with a module carrying bytes at three depths, a string-keyed map of bytes, and `uint32_t` params:

| shape | result |
|---|---|
| `[[bstr]]` param | `"2\|2,2:0:255:255,0:-1:-1:0\|0"` — byte-exact, empty elements kept |
| `{tstr: bstr}` param | `"2\|a=2:128:1:129\|b=0:-1:-1:0"` |
| `uint32_t` + `[uint]` param | `"7\|1\|4294967295"` — full range, author's own type |
| `[[bstr]]` return | `[[{"_bytes":"AP8"},{"_bytes":""}],[]]` |
| `{tstr: bstr}` return | `{"a":{"_bytes":"gAE"},"b":{"_bytes":""}}` |
| wrong-typed element | `{"code":"dispatch_failed","message":"expected integer at arg1[0], got string"}` |

**170/170 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)