### PR TITLE
fix(cdylib): the emitted codec accepts a whole-valued float as an integer

### DIFF
--- a/cpp-generator/experimental/lidl_gen_cdylib.cpp
+++ b/cpp-generator/experimental/lidl_gen_cdylib.cpp
@@ -238,6 +238,15 @@ void emitGeneratedCodec(QTextStream& s, const ModuleDecl& module,
     s << "template <> struct Codec<int64_t> {\n";
     s << "    static nlohmann::json to(const int64_t& v) { return nlohmann::json(v); }\n";
     s << "    static int64_t from(const nlohmann::json& j, const std::string& path) {\n";
+    s << "        if (j.is_number_float()) {\n";
+    s << "            const double d = j.get<double>();\n";
+    s << "            double ip = 0.0;\n";
+    s << "            if (std::modf(d, &ip) != 0.0)\n";
+    s << "                lidlTypeError(\"integer\", path, j);\n";
+    s << "            if (d < -9223372036854775808.0 || d >= 9223372036854775808.0)\n";
+    s << "                lidlTypeError(\"signed integer in range\", path, j);\n";
+    s << "            return static_cast<int64_t>(d);\n";
+    s << "        }\n";
     s << "        if (!j.is_number_integer() && !j.is_number_unsigned())\n";
     s << "            lidlTypeError(\"integer\", path, j);\n";
     s << "        if (j.is_number_unsigned()\n";
@@ -248,6 +257,15 @@ void emitGeneratedCodec(QTextStream& s, const ModuleDecl& module,
     s << "template <> struct Codec<uint64_t> {\n";
     s << "    static nlohmann::json to(const uint64_t& v) { return nlohmann::json(v); }\n";
     s << "    static uint64_t from(const nlohmann::json& j, const std::string& path) {\n";
+    s << "        if (j.is_number_float()) {\n";
+    s << "            const double d = j.get<double>();\n";
+    s << "            double ip = 0.0;\n";
+    s << "            if (std::modf(d, &ip) != 0.0)\n";
+    s << "                lidlTypeError(\"integer\", path, j);\n";
+    s << "            if (d < 0.0 || d >= 18446744073709551616.0)\n";
+    s << "                lidlTypeError(\"unsigned integer in range\", path, j);\n";
+    s << "            return static_cast<uint64_t>(d);\n";
+    s << "        }\n";
     s << "        if (!j.is_number_integer() && !j.is_number_unsigned())\n";
     s << "            lidlTypeError(\"integer\", path, j);\n";
     s << "        if (!j.is_number_unsigned() && j.get<int64_t>() < 0)\n";
@@ -526,7 +544,8 @@ QString lidlMakeTypesHeaderCdylib(const ModuleDecl& module)
     s << "#pragma once\n";
     s << "#include <logos_json.h>\n";
     s << "#include <cstdint>\n";
-    s << "#include <limits>\n";   // the integer codecs range-check
+    s << "#include <cmath>\n";    // the integer codecs accept whole-valued floats
+    s << "#include <limits>\n";   // ...and range-check
     s << "#include <map>\n";
     s << "#include <stdexcept>\n";
     s << "#include <string>\n";


### PR DESCRIPTION
Mirrors logos-co/logos-protocol#32. Both are needed: this generator emits its **own** codec into `<name>_types.h`, separate from `logos_codec.h`, so a rule applied to one copy leaves the other disagreeing — the same split that made the original scalar fix in #115 need two sites.

#115 made the emitted integer codecs check signedness. In doing so they started rejecting `3.0` as well as `3.7`, which broke four long-standing `test_basic_module_cpp` cases that pass a whole-valued double where the contract declares an integer:

```
addInts(3.0, 4.0)   echoInt(42.0)   isPositive(5.0)   twoArgs(hi, 3.0)
```

Those tests are right. JSON does not distinguish `3` from `3.0`, and this same emitted codec accepts an integral number for `float64` on exactly that reasoning. And logoscore's CLI types arguments by parsing, so `3.0` on a command line is a JSON float — rejecting it fails a call over a spelling.

A float now decodes as an integer when it has no fractional part and fits the range. **`3.7` is still refused**, which is what #115 was for.

Also adds `<cmath>` to the emitted include set for `std::modf`.

## Verification

- `logos-test-modules` **176/176**, four cases restored, 25 skips unchanged
- conformance matrix unchanged at **170 pass / 2 xfail** — `hostile/int/fractional` still expects and gets `dispatch_failed`
- cpp-sdk + protocol suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)