### PR TITLE
fix(generator): one Qt type mapper, and it knows about void; LpClient takes a timeout

### DIFF
--- a/cpp-generator/legacy/main.cpp
+++ b/cpp-generator/legacy/main.cpp
@@ -18,6 +18,7 @@
 #include "generator_lib.h"
 #include "../experimental/lidl_compat.h"
 #include "../experimental/impl_header_parser.h"
+#include "../experimental/lidl_emit_common.h"   // lidlTypeToQt — the one Qt type mapper
 
 // Escape a string for safe embedding inside a generated C++ string literal.
 static QString cppStringEscape(const QString& s)
@@ -32,43 +33,20 @@ static QString cppStringEscape(const QString& s)
 // Convert a TypeExpr → Qt-typed string name (same surface the
 // metaobject-introspection path produces for methods, so generator_lib
 // can consume both via one code path).
+//
+// ONE Qt type mapper. This used to be a near-duplicate of `lidlTypeToQt`
+// (experimental/lidl_emit_common.cpp) and the two disagreed: this copy had no
+// `void` case, so a `-> void` method reaching it as Primitive("void") from the
+// impl-header parser fell through to QVariant and generated
+// `QVariant doVoid(...)`. (The .lidl parser spells the same thing
+// Named("void"), which survived only by accident — mapReturnType's
+// `base == "void"` early-out.) The lp/std tables are DERIVED from this name, so
+// the same bug produced `LogosMap doVoid(...)` on the Qt-free surface: not a
+// Qt-only defect, a front-end one. It is now a delegation, so there is one
+// table to disagree with.
 static QString lidlTypeExprToQtTypeName(const TypeExpr& te)
 {
-    if (te.kind == TypeExpr::Primitive) {
-        if (te.name == "tstr")    return "QString";
-        if (te.name == "bstr")    return "QByteArray";
-        // 64-bit, and unsigned stays unsigned. LIDL int/uint are int64_t /
-        // uint64_t in every other binding; spelling them `int` here handed a
-        // Qt-style consumer a signed 32-bit value (silent truncation above
-        // 2^31) and a std/lp consumer a SIGNED int64_t for a `uint`.
-        if (te.name == "int")     return "qlonglong";
-        if (te.name == "uint")    return "qulonglong";
-        if (te.name == "float64") return "double";
-        if (te.name == "bool")    return "bool";
-        if (te.name == "result")  return "LogosResult";
-        if (te.name == "any")     return "QVariant";
-        return "QVariant";
-    }
-    if (te.kind == TypeExpr::Array && te.elements.size() == 1) {
-        const TypeExpr& elem = te.elements[0];
-        if (elem.kind == TypeExpr::Primitive && elem.name == "tstr")
-            return "QStringList";
-        // A list of records keeps its element type — the wrapper emits a
-        // typed container, not a bag of QVariants.
-        if (elem.kind == TypeExpr::Named)
-            return "QList<" + qs(elem.name) + ">";
-        return "QVariantList";
-    }
-    if (te.kind == TypeExpr::Map) {
-        if (te.elements.size() == 2 && te.elements[1].kind == TypeExpr::Named)
-            return "QMap<QString, " + qs(te.elements[1].name) + ">";
-        return "QVariantMap";
-    }
-    if (te.kind == TypeExpr::Optional) return "QVariant";
-    // A record declared by the contract: generator_lib emits the struct and
-    // types every mention of it with the struct.
-    if (te.kind == TypeExpr::Named)    return qs(te.name);
-    return "QVariant";
+    return lidlTypeToQt(te);
 }
 
 static QJsonArray moduleRecordsToJson(const ModuleDecl& mod);

--- a/cpp/logos_lp_client.h
+++ b/cpp/logos_lp_client.h
@@ -114,9 +114,16 @@ public:
 
     // Blocking call. `args` is a JSON array. Returns the result JSON value
     // (null on failure); fills `err` when non-null.
+    //
+    // `timeout_ms <= 0` selects the protocol default (the C ABI's rule), which
+    // is what every caller got before the parameter existed — so adding it
+    // changes nothing for them. It exists because the Qt-typed consumer surface
+    // takes a `Timeout` on every async overload and had nowhere to put it: a
+    // wrapper delegating here silently dropped the caller's timeout.
     nlohmann::json invoke(const std::string& method,
                           const nlohmann::json& args,
-                          CallError* err) {
+                          CallError* err,
+                          int timeout_ms = 0) {
         lp_client* c = ensure();
         if (!c) {
             if (err) { err->code = "object_unavailable";
@@ -127,7 +134,7 @@ public:
         const std::string argsStr = args.dump();
         char* outRes = nullptr;
         char* outErr = nullptr;
-        const int rc = lp_invoke(c, method.c_str(), argsStr.c_str(), 0, &outRes, &outErr);
+        const int rc = lp_invoke(c, method.c_str(), argsStr.c_str(), timeout_ms, &outRes, &outErr);
         nlohmann::json result;  // null
         if (rc == LP_OK) {
             if (err) err->clear();
@@ -147,12 +154,13 @@ public:
     // failure / parse error). Safe to call from any thread.
     void invokeAsync(const std::string& method,
                      const nlohmann::json& args,
-                     std::function<void(nlohmann::json)> cb) {
+                     std::function<void(nlohmann::json)> cb,
+                     int timeout_ms = 0) {
         lp_client* c = ensure();
         if (!c) { if (cb) cb(nullptr); return; }
         auto* box = new std::function<void(nlohmann::json)>(std::move(cb));
         const std::string argsStr = args.dump();
-        lp_invoke_async(c, method.c_str(), argsStr.c_str(), 0,
+        lp_invoke_async(c, method.c_str(), argsStr.c_str(), timeout_ms,
             &LpClient::resultTrampoline, box);
     }
 


### PR DESCRIPTION
Two prerequisites for logos-co/logos-qt-sdk#… (the Qt consumer veneer), both of which stand on their own.

## One Qt type mapper

There were two, and they disagreed:

| | `void` |
|---|---|
| `cpp-generator/legacy/main.cpp` `lidlTypeExprToQtTypeName` | no case → falls through to `QVariant` |
| `cpp-generator/experimental/lidl_emit_common.cpp` `lidlTypeToQt` | handled |

That is why a `.h`-interface module generated `QVariant doVoid(...)` while a `.lidl` one generated `void doVoid(...)`, and why the shipped `test_fullapi_proxy` carries `LogosMap doVoid(...)` today.

Measured on the two **real in-tree `.h` interfaces**, not a fixture — `test-fullapi-ui-module/interfaces/full_api.h` and `test-fullapi-proxy-module-cpp/interfaces/full_api.h`:

```
--api-style qt   before  QVariant doVoid(…)     after  void doVoid(…)
--api-style lp   before  LogosMap doVoid(…)     after  void doVoid(…)
```

This is the third `void`-falls-to-the-catch-all bug in this codebase — after the Rust backend (M2) and the cdylib glue. `void` is not a LIDL builtin, so it arrives as `Named("void")` and every mapper that forgets it silently produces something plausible. Having one mapper is the actual fix.

## `LpClient::invokeAsync` takes a timeout

It had no timeout parameter and hardcoded `timeout_ms = 0`, while every Qt async overload takes `Timeout timeout = Timeout()` and threads it through. A veneer over lp would have kept the parameter and silently ignored it — so this closes the gap before anything depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)