### PR TITLE
fix(generator): the provider dispatch decodes arguments, it does not coerce

### DIFF
--- a/cpp-generator/legacy/generator_lib.cpp
+++ b/cpp-generator/legacy/generator_lib.cpp
@@ -52,6 +52,35 @@ QString mapReturnType(const QString& qtType)
     return QString("QVariant");
 }
 
+// How an INCOMING provider argument is turned into the type the author
+// declared. Not the same job as toQVariantConversion below, which converts a
+// value the module already owns.
+//
+// The Qt conversions coerce: `args.at(0).toULongLong()` turned echoUint(-1)
+// into 18446744073709551615 and `.toLongLong()` turned echoInt(3.7) into 4, so
+// the author's method body never saw the value the caller actually sent, while
+// every non-Qt provider answered {"code":"dispatch_failed"} for the same input.
+// logos::qtArgFromVariant<T> routes the value through the canonical codec
+// instead — one rule, shared with the QMetaObject dispatch in logos-qt-sdk, and
+// deliberately NOT re-derived here (the codec is what knows that a whole-valued
+// 3.0 is a legal integer and 3.7 is not).
+//
+// A type the codec has no rule for keeps the old conversion verbatim: those are
+// module-author types the generator already treated as `any`, and routing them
+// through the codec would be a compile error rather than a behaviour change.
+QString toProviderArgDecode(const QString& type, const QString& argExpr,
+                            const QString& path)
+{
+    static const QSet<QString> codecKnown = {
+        "bool","int","qlonglong","qulonglong","double","float",
+        "QString","QStringList","QByteArray","QJsonArray","QJsonObject",
+        "QVariantList","QVariantMap","QVariant","LogosResult"
+    };
+    if (!codecKnown.contains(type))
+        return toQVariantConversion(type, argExpr);
+    return "logos::qtArgFromVariant<" + type + ">(" + argExpr + ", \"" + path + "\")";
+}
+
 QString toQVariantConversion(const QString& type, const QString& argExpr)
 {
     if (type == "int") return argExpr + ".toInt()";

--- a/cpp-generator/legacy/generator_lib.h
+++ b/cpp-generator/legacy/generator_lib.h
@@ -49,6 +49,13 @@ QString mapParamType(const QString& qtType);
 QString mapReturnType(const QString& qtType);
 QString toQVariantConversion(const QString& type, const QString& argExpr);
 
+// Incoming provider argument -> the declared type, via the canonical codec
+// (logos::qtArgFromVariant). `path` names the slot in the diagnostic a
+// rejection carries, e.g. "arg0". See the definition for why this is separate
+// from toQVariantConversion.
+QString toProviderArgDecode(const QString& type, const QString& argExpr,
+                            const QString& path);
+
 // makeHeader / makeSource emit the single `<Class>` wrapper for a
 // module. When `apiStyle == Std`, parameter / return types come from
 // the std-typed mapping table (std::string / std::vector<std::string>

--- a/cpp-generator/legacy/main.cpp
+++ b/cpp-generator/legacy/main.cpp
@@ -696,6 +696,8 @@ static int generateProviderDispatch(const QString& headerPath, const QString& ou
     s << "#include <QVariant>\n";
     s << "#include <QString>\n";
     s << "#include \"logos_types.h\"\n";
+    // The canonical argument decoder — the Qt face of logos::fromJson<T>.
+    s << "#include \"logos_qt_arg_decode.h\"\n";
     s << "#include <exception>\n\n";
 
     // callMethod() — group by name to support overloaded methods
@@ -724,7 +726,9 @@ static int generateProviderDispatch(const QString& headerPath, const QString& ou
             if (m->returnType == "void" || m->returnType.isEmpty()) {
                 s << "        " << m->name << "(";
                 for (int i = 0; i < m->params.size(); ++i) {
-                    s << toQVariantConversion(m->params[i].first, QString("args.at(%1)").arg(i));
+                    s << toProviderArgDecode(m->params[i].first,
+                                             QString("args.at(%1)").arg(i),
+                                             QString("arg%1").arg(i));
                     if (i + 1 < m->params.size()) s << ", ";
                 }
                 s << ");\n";
@@ -733,7 +737,9 @@ static int generateProviderDispatch(const QString& headerPath, const QString& ou
             } else {
                 s << "        return QVariant::fromValue(" << m->name << "(";
                 for (int i = 0; i < m->params.size(); ++i) {
-                    s << toQVariantConversion(m->params[i].first, QString("args.at(%1)").arg(i));
+                    s << toProviderArgDecode(m->params[i].first,
+                                             QString("args.at(%1)").arg(i),
+                                             QString("arg%1").arg(i));
                     if (i + 1 < m->params.size()) s << ", ";
                 }
                 s << "));\n";
@@ -744,6 +750,18 @@ static int generateProviderDispatch(const QString& headerPath, const QString& ou
         }
         s << "    }\n";
     }
+    // An argument the declared type cannot represent is a REJECTED call, not a
+    // failed one: it answers the canonical {"code":"dispatch_failed", ...}
+    // object — byte-identical to what the cdylib dispatch and the Rust provider
+    // return — so the caller can tell "you sent me the wrong thing" from "the
+    // method threw". Anything else the author lets escape stays an ordinary
+    // method failure (invalid QVariant) rather than unwinding through Qt event
+    // dispatch and killing the module process.
+    s << "    } catch (const logos::CodecError& e) {\n";
+    s << "        qWarning() << \"" << className
+      << "::callMethod:\" << methodName << \"rejected:\" << e.what();\n";
+    s << "        return logos::dispatchFailedVariant(providerName(), "
+         "QString::fromUtf8(e.what()));\n";
     s << "    } catch (const std::exception& e) {\n";
     s << "        qWarning() << \"" << className
       << "::callMethod:\" << methodName << \"failed:\" << e.what();\n";


### PR DESCRIPTION
The generator half of registry entry Q1. Stacked on logos-co/logos-protocol#36 (the shared decoder) — merge that first.

`generator_lib.cpp:55-72` emitted a per-type coercion table into every generated provider dispatch:

```cpp
if (type == "qulonglong") return argExpr + ".toULongLong()";
```

so the generated file read literally `echoUint(args.at(0).toULongLong())` — which turns `-1` into `18446744073709551615` with no signal. It now emits a call to the shared decoder instead.

Measured on `test_fullapi_qtproxy`, before → after: `echoUint(-1)`, `echoInt(3.7)`, `echoBool(1)`, `echoStringList(["a",1])` and two more all flip to `dispatch_failed`, matching what a direct call and the lp proxy already answered.

## Scope note

`toQVariantConversion` is also called from `fromWireFor` for the Qt **consumer** wrapper's *return* conversion. That is the opposite direction and is untouched.

## Honest reach

This emitter has **no production users** — three test modules and a qt-sdk fixture; no module in the workspace sets `interface: "provider"`. The shipping instance of this defect is in logos-co/logos-qt-sdk#22. This PR matters because it is what the conformance matrix measures through, and because leaving one of three copies uncorrected is how the divergence would return.

Verified together with the other two arms: **226/226**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)