### PR TITLE
docs: drop the reference to the deleted lidlGenerateProviderGlue

### DIFF
--- a/cpp-generator/docs/project.md
+++ b/cpp-generator/docs/project.md
@@ -135,7 +135,6 @@ Flag plumbing:
   - Always emits `#include "logos_sdk.h"` and a `std::unique_ptr<LogosModules> m_logosModules` member; ownership lives on the provider, the context base sees only a non-owning `void*` reinterpreted in `LogosModuleContext::modules()` (which depends on the impl's TU having included `logos_sdk.h`).
 - `lidlMakeProviderDispatch(ModuleDecl)` — generates callMethod/getMethods dispatch. `getMethods()` emits the full interface: each method tagged `type: "method"`, then each `module.events` entry tagged `type: "event"` (name, signature, parameters, escaped `description`; no returnType/isInvokable). There is no separate `getEvents()` — folding events into `getMethods()` keeps the provider vtable ABI-stable.
 - `lidlMakeEventsSource(ModuleDecl, implClass, implHeader)` — generates `<name>_events.cpp`: Qt-MOC-style method bodies for prototypes declared in the impl's `logos_events:` block. Each body marshals typed args into a `QVariantList` and calls `this->emitEventImpl_("<name>", &args)` on the LogosModuleContext base.
-- `lidlGenerateProviderGlue(lidlPath, ...)` — full pipeline from .lidl file. Also emits `<name>_events.cpp` and a `<name>.lidl` sidecar (via `lidlSerialize`) when the module has any events; both ride the dep's `headers-*` outputs to power consumer-side typed `on<X>()` accessors.
 
 ### Impl Header Parser (`impl_header_parser.h/cpp`)
 


### PR DESCRIPTION
Doc-only. logos-qt-sdk#23 deleted `lidlGenerateProviderGlue` — a second, parallel top-level pipeline over the same emitters `main.cpp` already drives, with no callers anywhere in the workspace. This bullet in `cpp-generator/docs/project.md` was its only surviving reference.

The `<name>.lidl` sidecar the bullet described is emitted elsewhere and is unaffected: `main.cpp:92`/`:184` here, and module-builder's `modulePreConfigure.nix:75`.

Deferred at the time because this repo's working tree was busy with concurrent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)