### PR TITLE
chore(deps): bump logos-protocol to 3a31c91d (off-strand socket close races)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785470728,
-        "narHash": "sha256-K6rr5ycCWctvtUnktskjRlXHN3GuI7FEbz8/FX+pVY8=",
+        "lastModified": 1785523697,
+        "narHash": "sha256-8WdoCJDLNR/aLkcmeY8CeAZlTIN8ulG/7N1ZFEVDdsQ=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "72754ab9b2ea8a43a3f04c5bdf1411673f3f489e",
+        "rev": "3a31c91d1322dae053bbe28b6e3f441fabcc2162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `logos-protocol` **72754ab9 → 3a31c91d**. One file, one lock node, three lines.

Step 2 of a four-repo propagation chain. **Merge after [logos-liblogos#172](https://github.com/logos-co/logos-liblogos/pull/172).**

## What is being propagated

Two off-strand socket-close races in the plain (tcp / tcp_ssl) transports:

| | |
|---|---|
| logos-protocol#38 | `RpcConnection::fail()` closed the socket on the caller's thread while every other stream access was serialized on `m_strand`, racing `kqueue_reactor::start_op` and segfaulting the client on teardown. |
| logos-protocol#39 | The same class of bug on `RpcServer`'s acceptor. |

Both are **false negatives**, not lost work: the RPC completes and prints its correct result, then teardown crashes — so a caller that checks the exit code before parsing stdout reports a healthy call as failed. Measured at ~0.45% of calls over tcp/tcp_ssl, zero over local/QtRO.

The upstream diff between the two revs is exactly two commits and touches only `cpp/implementations/plain/rpc_connection.h`, `rpc_server.{h,cpp}`, and protocol's own tests.

## What this bump does *not* do

`logos-cpp-sdk` ships **no protocol runtime code**. The header-only SDK (`nix/lib.nix`) does not link protocol at all; the generator only `#include`s protocol headers (`logos_provider_interface.h`, `logos_json_convert.h`). Confirmed on the built artifact:

- no `logos-protocol` store path anywhere in the generator's runtime closure
- `otool -L` lists no logos dylib
- `nm` finds 0 `logos::plain` symbols and 0 `closeStreamOnStrand` / `closeAcceptorOnStrand`

So this is a **propagation** bump: cpp-sdk's pin is what downstream repos inherit through `follows`. The fix reaches running code in liblogos and in the frontends, not here.

## Closure check — every protocol node, not just the root one

Root pin bumps are famously insufficient (`logos-logoscore-cli` had the fixed rev at the root and still crashed 4/2000, because liblogos brought its own older protocol). So the whole closure was enumerated with a resolver that treats a `follows` entry as a **path array resolved from the root node**, not as a node name.

cpp-sdk's lock is 5 nodes: `logos-lidl`, `logos-nix`, `logos-protocol`, `nixpkgs`, `root`. Exactly **one** protocol node, one resolved edge, now at `3a31c91d`. `logos-lidl` and `logos-nix` have no protocol input. Nothing to reconcile.

## Verification

**1. The generator binary is byte-identical across the bump.**

`bin/.logos-cpp-generator-wrapped` — the real binary — is `sha256:1ceb6b9d2517d58fdc5166dfe561444bf941588ae75aad7841152769ce920300` on both sides. The only differing file in the whole derivation is the Nix C wrapper, and it differs only in its own embedded store path. Symbol tables are identical; `strings` differs only in that path. This is fully explained by the upstream diff not touching any header the generator reads.

**2. Emitted-code equivalence, base vs bumped generator.**

"It built" proves little when a cpp-sdk change rebuilds the whole graph, so the generator was built at both revs and its *output* diffed over every `.lidl` file and impl header in the workspace (deduplicated by content hash — 16 unique `.lidl`, 5 unique impl headers).

| mode | invocation pairs | emitted files (base) | differences |
|---|---|---|---|
| `--general-only --interface`, `--api-style qt` + `lp` | 42 | 168 | 0 |
| `--general-only --dep`, `--api-style qt` + `lp` | 42 | 168 | 0 |
| `--lidl` (client wrapper) | 16 | 65 | 0 |
| `--lidl --backend cdylib` (no `--impl-class`) | 16 | 0 | 0 |
| `--lidl --backend cdylib --impl-class` (C-ABI exports) | 16 | 44 | 0 |
| `--from-header --backend cdylib` | 5 | 19 | 0 |
| `--header-to-lidl` | 5 | 5 | 0 |
| **total** | **142** | **469** | **0** |

The zero-file row is not a gap: `--lidl --backend cdylib` without `--impl-class` is *refused* by design ("the uniform cdylib Qt glue is generated by logos-qt-generator"), identically on both sides, with the same exit code 12 and the same stderr. The `--impl-class` row below it covers that emission path with output.

Exit codes, stdout and stderr were compared too, not just file contents.

**3. The harness was proved sensitive before its "identical" was believed.**

- *Negative control:* `--api-style qt` vs `lp` on the same generator differ in **42/42** runs. (The `--lidl` mode ignores `--api-style` and yields a false "identical" — that trap has caught this project twice, so api-style sensitivity is claimed only from the `--general-only` path, which honours it.)
- *Mutation control:* renaming every `method`/`event` identifier in each input changes the output in **39/39** runs that succeed unmutated (23 in the provider/`--lidl` pass, 16 in the cdylib C-ABI pass).

**4. Unit tests: 218/218 pass — identical to origin/master (218/218).**

Both sides built and run from a clean `nix build .#tests` (aarch64-darwin). No regression and no new coverage; cpp-sdk's test binaries contain 0 `logos::plain` symbols, so they do not exercise the fixed code either.

**5. CI is fully green.**

| check | result |
|---|---|
| `test` | pass (1m09s) |
| `cpp-sdk doc-tests (ubuntu-latest)` | pass (13m20s) — **101 passed, 0 failed, 0 skipped of 101** |
| `cpp-sdk doc-tests (macos-latest)` | pass (14m43s) — **101 passed, 0 failed, 0 skipped of 101** |
| `Publish report to GitHub Pages` | pass (18s) |

All five doctest specs ran on both platforms: `cpp-sdk-module-runtime`, `cpp-sdk-module-composition`, `cpp-sdk-worker-thread-http`, `cpp-sdk-concurrent-dispatch`, `cpp-sdk-generator-roundtrip`. Note these build a real module and run it through `logoscore` against **this** commit of the SDK, so they do exercise the runtime — unlike the unit tests.

## Pre-existing, not caused by this bump

Three `.lidl` files under `repos/logos-test-modules/.claude/worktrees/` fail the generator with `Unknown type 'void'` — **identically on both sides**. They are stale worktree copies using a spelling the generator now rejects by design (44b92b0, "no silent admissions"). Not a finding against this PR; worth someone's attention as workspace hygiene.

## Merge order

1. logos-liblogos#172 — protocol 4ee85b26 → 3a31c91d
2. **this PR** — protocol 72754ab9 → 3a31c91d
3. logos-qt-sdk — pins protocol *and* cpp-sdk
4. logos-module-builder — follows protocol, pins cpp-sdk / qt-sdk / rust-sdk

`logos-rust-sdk` needs no bump: it has no `logos-protocol` input and receives protocol transitively through module-builder, so it moves with step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
