### PR TITLE
fix(generator): the Qt consumer must not flatten a rejection into an empty value

### DIFF
--- a/cpp-generator/docs/project.md
+++ b/cpp-generator/docs/project.md
@@ -320,3 +320,16 @@ Fixture files in `tests/experimental/fixtures/`:
   single-`_bytes`-field record is refused under both spellings. It used to read `f.type`,
   which refused `? _bytes: tstr` and let `_bytes: ?tstr` through — the same declaration,
   two answers. `?bstr` is unaffected either way: the tag lives in the value, not the slot.
+- **A provider REJECTION reaches an async consumer callback only as a log line.** A
+  provider that refuses a call answers the canonical
+  `{"code":"dispatch_failed", "message":…, "origin":…}` object as its RESULT, not as a
+  transport error, and the Qt return table would convert it like any other value —
+  erasing it (`_result.toList()` on that map is `[]`). The Qt consumer emitter therefore
+  detects it and folds it into the `logos::CallError` out-parameter the sync wrapper
+  already carries, so `mod.echoUintList(v, &err)` can tell a rejection from an empty
+  return. The generated `…Async` overload has no such channel — its callback is
+  `std::function<void(T)>`, and adding an error parameter would change the generated
+  public surface (which logos-qt-sdk's `qt-generator --backend consumer` veneer mirrors
+  1:1) — so an async rejection is reported with `qWarning` and the callback still
+  receives the default-converted value. Giving async an error channel is an API change,
+  not a code-generation fix.

--- a/cpp-generator/legacy/generator_lib.cpp
+++ b/cpp-generator/legacy/generator_lib.cpp
@@ -603,8 +603,14 @@ QString makeHeader(const QString& moduleName, const QString& className, const QJ
 // already uses to report a failed call, so a rejection reads exactly like every
 // other failure on this surface — no new signature, no new type, and no change
 // to any return value.
+// Guarded because the umbrella (`logos_sdk.cpp`) textually #includes EVERY
+// generated `<dep>_api.cpp`, so a module with more than one dependency puts
+// several of these in ONE translation unit. Internal linkage handles the
+// separate-TU case; only the preprocessor handles this one.
 static void emitDispatchRejectionDetector(QTextStream& s)
 {
+    s << "#ifndef LOGOS_GENERATED_DISPATCH_REJECTION\n";
+    s << "#define LOGOS_GENERATED_DISPATCH_REJECTION\n\n";
     s << "namespace {\n\n";
     s << "// True when `v` is the canonical provider REJECTION object rather than a\n";
     s << "// value; fills `out` with its {code, message, origin} on a match.\n";
@@ -635,6 +641,7 @@ static void emitDispatchRejectionDetector(QTextStream& s)
     s << "    return true;\n";
     s << "}\n\n";
     s << "} // namespace\n\n";
+    s << "#endif  // LOGOS_GENERATED_DISPATCH_REJECTION\n\n";
 }
 
 QString makeSource(const QString& moduleName, const QString& className, const QString& headerBaseName, const QJsonArray& methods, ApiStyle apiStyle, const QJsonArray& events, BindMode bindMode, const QJsonArray& records)

--- a/cpp-generator/legacy/generator_lib.cpp
+++ b/cpp-generator/legacy/generator_lib.cpp
@@ -588,20 +588,82 @@ QString makeHeader(const QString& moduleName, const QString& className, const QJ
     return h;
 }
 
+// The Qt consumer's rejection detector, emitted once per generated wrapper.
+//
+// A provider that REJECTS a call answers the canonical
+// {"code":"dispatch_failed", "message":..., "origin":...} object as its RESULT,
+// not as a transport error. Every provider flavour produces the same object
+// (logos-qt-sdk `dispatchFailedVariant`, the generated cdylib dispatch, the Rust
+// provider's `args::dispatch_failed`), and the Qt return table converts it like
+// any other value — which ERASES it: `_result.toList()` on a map is `[]`,
+// `.toString()` is "", `.toLongLong()` is 0. A caller then cannot tell "you sent
+// me the wrong thing" from "the provider returned nothing".
+//
+// Detected here and folded into the logos::CallError out-channel the wrapper
+// already uses to report a failed call, so a rejection reads exactly like every
+// other failure on this surface — no new signature, no new type, and no change
+// to any return value.
+static void emitDispatchRejectionDetector(QTextStream& s)
+{
+    s << "namespace {\n\n";
+    s << "// True when `v` is the canonical provider REJECTION object rather than a\n";
+    s << "// value; fills `out` with its {code, message, origin} on a match.\n";
+    s << "//\n";
+    s << "// The match is exact — those three fields, all strings, and that code — for the\n";
+    s << "// same reason logos_rpc_status.h's isUnauthorizedSentinel is exact: an `any` or\n";
+    s << "// map return carrying user data must never false-match.\n";
+    s << "bool logosDispatchRejection(const QVariant& v, logos::CallError& out)\n";
+    s << "{\n";
+    s << "    QVariantMap m;\n";
+    s << "    switch (v.userType()) {\n";
+    s << "    case QMetaType::QVariantMap: m = v.toMap(); break;\n";
+    s << "    // Defensive: some json_convert paths historically produced QJsonObject.\n";
+    s << "    case QMetaType::QJsonObject: m = v.toJsonObject().toVariantMap(); break;\n";
+    s << "    default: return false;\n";
+    s << "    }\n";
+    s << "    if (m.size() != 3) return false;\n";
+    s << "    const QVariant code = m.value(QStringLiteral(\"code\"));\n";
+    s << "    const QVariant message = m.value(QStringLiteral(\"message\"));\n";
+    s << "    const QVariant origin = m.value(QStringLiteral(\"origin\"));\n";
+    s << "    if (code.userType() != QMetaType::QString\n";
+    s << "        || message.userType() != QMetaType::QString\n";
+    s << "        || origin.userType() != QMetaType::QString) return false;\n";
+    s << "    if (code.toString() != QStringLiteral(\"dispatch_failed\")) return false;\n";
+    s << "    out.code = code.toString().toStdString();\n";
+    s << "    out.message = message.toString().toStdString();\n";
+    s << "    out.origin = origin.toString().toStdString();\n";
+    s << "    return true;\n";
+    s << "}\n\n";
+    s << "} // namespace\n\n";
+}
+
 QString makeSource(const QString& moduleName, const QString& className, const QString& headerBaseName, const QJsonArray& methods, ApiStyle apiStyle, const QJsonArray& events, BindMode bindMode, const QJsonArray& records)
 {
     if (apiStyle == ApiStyle::Lp)
         return makeSourceLp(moduleName, className, headerBaseName, methods, events, bindMode, records);
     const RecordSet rs = parseRecords(records);
+    // The rejection detector is only reachable from a method body, so a
+    // contract with no invokable method must not emit it (an unused function in
+    // an anonymous namespace is a -Wunused-function warning, and such a
+    // contract's wrapper stays byte-identical to what it generated before).
+    bool anyInvokable = false;
+    for (const QJsonValue& mv : methods) {
+        if (mv.toObject().value("isInvokable").toBool()) { anyInvokable = true; break; }
+    }
     QString c;
     QTextStream s(&c);
     s << "#include \"" << headerBaseName << "\"\n\n";
     s << "#include <QDebug>\n";
-    if (!rs.isEmpty()) {
-        // Record conversions build QVariantMaps.
+    if (!rs.isEmpty() || anyInvokable) {
+        // Record conversions build QVariantMaps; so does the rejection detector.
         s << "#include <QVariantMap>\n";
     }
+    if (anyInvokable) {
+        // The rejection detector reads a QJsonObject-shaped result defensively.
+        s << "#include <QJsonObject>\n";
+    }
     s << "\n";
+    if (anyInvokable) emitDispatchRejectionDetector(s);
     emitRecordConversions(s, rs, apiStyle, className);
     // The expression every remote call uses to name its target module.
     // Static: the baked string literal "<moduleName>" (unchanged
@@ -748,13 +810,15 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
 
         // Body: perform call through the err-out overload. When the caller
         // passes a logos::CallError* it can distinguish a failed remote call
-        // (e.g. the bound module is missing) from a legitimately
-        // default-valued result; without it the historical default-on-failure
-        // behavior is kept, now with a warning so failures are at least
-        // visible in the module log.
+        // (e.g. the bound module is missing, or the provider REJECTED the
+        // arguments) from a legitimately default-valued result; without it the
+        // historical default-on-failure behavior is kept, now with a warning so
+        // failures are at least visible in the module log.
+        //
+        // The result is captured even for a `void` return: a void method can be
+        // rejected too, and the rejection object is the only place that says so.
         s << "    logos::CallError _err;\n";
-        if (ret != "void") s << "    QVariant _result = ";
-        else               s << "    ";
+        s << "    QVariant _result = ";
 
         // Wrap each argument in QVariant::fromValue so it becomes exactly ONE
         // element of the args list. A bare `QVariantList{v}` CONCATENATES a
@@ -768,6 +832,11 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
             if (i + 1 < params.size()) s << ", ";
         }
         s << "}, Timeout(), &_err);\n";
+        // A provider REJECTION arrives as the result, not as a transport error.
+        // Fold it into the same error channel BEFORE the return table converts
+        // it, or the conversion erases it (a rejected `[uint]` call answered []
+        // — the whole list, not the bad element).
+        s << "    if (_err.ok()) logosDispatchRejection(_result, _err);\n";
         s << "    if (err) *err = _err;\n";
         s << "    else if (!_err.ok()) qWarning() << \"" << className << "::" << name
           << ": remote call failed:\" << QString::fromStdString(_err.message);\n";
@@ -836,6 +905,13 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
             s << "}";
         }
         s << ", [callback](QVariant v) {\n";
+        // The async callback carries the value only — there is no CallError
+        // parameter to fill, and adding one would change the generated public
+        // surface. A rejection is at least made visible in the module log
+        // instead of vanishing into the return conversion below.
+        s << "        { logos::CallError _rej; if (logosDispatchRejection(v, _rej))\n";
+        s << "              qWarning() << \"" << className << "::" << name
+          << "Async: remote call failed:\" << QString::fromStdString(_rej.message); }\n";
         if (ret == "void") {
             s << "        (void)v; callback();\n";
         } else if (retIsRecord) {

--- a/tests/generator/test_make_source.cpp
+++ b/tests/generator/test_make_source.cpp
@@ -292,3 +292,91 @@ TEST(MakeSourceTest, NonInvokableSkipped)
     QString src = makeSource("mod", "Mod", "mod.h", methods);
     EXPECT_FALSE(src.contains("hidden"));
 }
+
+// ─── The provider REJECTION envelope on the return path ─────────────────────
+//
+// A provider that refuses a call answers the canonical
+// {"code":"dispatch_failed", "message":…, "origin":…} object as its RESULT. The
+// Qt return table converts it like any other value, which ERASES it — a rejected
+// `[uint]` call answered `[]`, indistinguishable from "the provider returned
+// nothing". These pin the consumer folding it into the CallError out-channel the
+// wrapper already uses for a failed call.
+
+TEST(MakeSourceTest, QtEmitsRejectionDetector)
+{
+    QJsonArray methods;
+    methods.append(makeMethod("fn", "QVariantList", 1));
+    QString src = makeSource("mod", "Mod", "mod.h", methods);
+    EXPECT_TRUE(src.contains("bool logosDispatchRejection(const QVariant& v, logos::CallError& out)"));
+    // Exact match only: an `any` / map return carrying user data must not
+    // false-match (same discipline as logos_rpc_status.h's sentinel).
+    EXPECT_TRUE(src.contains("if (m.size() != 3) return false;"));
+    EXPECT_TRUE(src.contains("if (code.toString() != QStringLiteral(\"dispatch_failed\")) return false;"));
+}
+
+TEST(MakeSourceTest, QtSyncFoldsRejectionIntoCallError)
+{
+    QJsonArray methods;
+    methods.append(makeMethod("echoUintList", "QVariantList", 1));
+    QString src = makeSource("mod", "Mod", "mod.h", methods);
+    // Folded BEFORE the return table converts the value, and before *err is
+    // written, so a caller passing err sees the rejection.
+    const int fold = src.indexOf("if (_err.ok()) logosDispatchRejection(_result, _err);");
+    const int assign = src.indexOf("if (err) *err = _err;");
+    const int convert = src.indexOf("return _result.toList();");
+    EXPECT_NE(fold, -1);
+    EXPECT_NE(assign, -1);
+    EXPECT_NE(convert, -1);
+    EXPECT_LT(fold, assign);
+    EXPECT_LT(assign, convert);
+}
+
+TEST(MakeSourceTest, QtVoidReturnStillCapturesResult)
+{
+    // A void method can be rejected too, and the rejection object is the only
+    // place that says so — so the result has to be captured even when it is
+    // never returned.
+    QJsonArray methods;
+    methods.append(makeMethod("doVoid", "void", 0));
+    QString src = makeSource("mod", "Mod", "mod.h", methods);
+    EXPECT_TRUE(src.contains("QVariant _result = m_client->invokeRemoteMethod(\"mod\", \"doVoid\""));
+    EXPECT_TRUE(src.contains("if (_err.ok()) logosDispatchRejection(_result, _err);"));
+}
+
+TEST(MakeSourceTest, QtAsyncLogsRejection)
+{
+    // The async callback takes the value alone — there is no CallError to fill
+    // without changing the generated public surface — so the rejection has to at
+    // least reach the module log instead of vanishing into the conversion.
+    QJsonArray methods;
+    methods.append(makeMethod("fn", "QVariantList", 1));
+    QString src = makeSource("mod", "Mod", "mod.h", methods);
+    EXPECT_TRUE(src.contains("{ logos::CallError _rej; if (logosDispatchRejection(v, _rej))"));
+    EXPECT_TRUE(src.contains("Mod::fnAsync: remote call failed:"));
+}
+
+TEST(MakeSourceTest, QtNoInvokableMethodsEmitsNoDetector)
+{
+    // Unreachable from any body: emitting it would be an unused function in an
+    // anonymous namespace (-Wunused-function), and such a contract's wrapper
+    // stays byte-identical to what it generated before.
+    QJsonArray methods;
+    QJsonObject m;
+    m["name"] = "hidden";
+    m["returnType"] = "void";
+    m["isInvokable"] = false;
+    m["parameters"] = QJsonArray();
+    methods.append(m);
+    QString src = makeSource("mod", "Mod", "mod.h", methods);
+    EXPECT_FALSE(src.contains("logosDispatchRejection"));
+}
+
+TEST(MakeSourceTest, LpSurfaceIsUntouched)
+{
+    // The fix is Qt-consumer-only; the lp wrapper must generate exactly as
+    // before (byte-identical output is the negative control for the change).
+    QJsonArray methods;
+    methods.append(makeMethod("fn", "QVariantList", 1));
+    QString src = makeSource("mod", "Mod", "mod.h", methods, ApiStyle::Lp);
+    EXPECT_FALSE(src.contains("logosDispatchRejection"));
+}

--- a/tests/generator/test_make_source.cpp
+++ b/tests/generator/test_make_source.cpp
@@ -380,3 +380,22 @@ TEST(MakeSourceTest, LpSurfaceIsUntouched)
     QString src = makeSource("mod", "Mod", "mod.h", methods, ApiStyle::Lp);
     EXPECT_FALSE(src.contains("logosDispatchRejection"));
 }
+
+TEST(MakeSourceTest, QtRejectionDetectorIsPreprocessorGuarded)
+{
+    // The umbrella (logos_sdk.cpp) textually #includes EVERY generated
+    // `<dep>_api.cpp`, so a module with more than one dependency puts several
+    // copies in ONE translation unit — "redefinition of logosDispatchRejection".
+    // Internal linkage does not help there; only the guard does.
+    QJsonArray methods;
+    methods.append(makeMethod("fn", "QVariantList", 1));
+    QString src = makeSource("mod", "Mod", "mod.h", methods);
+    EXPECT_TRUE(src.contains("#ifndef LOGOS_GENERATED_DISPATCH_REJECTION"));
+    EXPECT_TRUE(src.contains("#define LOGOS_GENERATED_DISPATCH_REJECTION"));
+    EXPECT_TRUE(src.contains("#endif  // LOGOS_GENERATED_DISPATCH_REJECTION"));
+    // Concatenating two generated wrappers, as the umbrella does, must compile:
+    // the second copy is preprocessed away.
+    QString other = makeSource("dep", "Dep", "dep.h", methods);
+    EXPECT_EQ(other.count("bool logosDispatchRejection"), 1);
+    EXPECT_EQ((src + other).count("#ifndef LOGOS_GENERATED_DISPATCH_REJECTION"), 2);
+}


### PR DESCRIPTION
## What

A Qt consumer flattened a provider **rejection** into an empty value, so the caller
never saw the error.

A provider that REJECTS a call answers the canonical
`{"code":"dispatch_failed", "message":…, "origin":…}` object **as its RESULT**, not as a
transport error. Every provider flavour produces the same object — logos-qt-sdk's
`dispatchFailedVariant`, the generated cdylib dispatch, the Rust provider's
`args::dispatch_failed`.

The generated Qt consumer wrapper (`legacy/main.cpp` → `generateInterfaceWrappers` →
`generator_lib.cpp` `makeSource`, i.e. the path every real module builds through:
logos-plugin-qt `buildPlugin.nix` runs
`logos-cpp-generator --metadata … --general-only --api-style qt`) converted it like any
other value, which **erases** it:

```cpp
QVariant _result = m_client->invokeRemoteMethod(…, &_err);
if (err) *err = _err;                    // only ever a TRANSPORT error
return _result.toList();                 // the rejection map -> []
```

So `echoUintList([1, -1, 3])`, answered `dispatch_failed` by the provider, reached the
caller as `[]` — the whole list, not the bad element, and indistinguishable from "the
provider returned nothing". That is registry entry **Q1**'s consumer half
(logos-test-modules `conformance/known.json`).

## The fix

Report it through the channel this surface **already** uses for a failed call — the
`logos::CallError*` out-parameter every generated sync method carries (today
`object_unavailable` when the target module cannot be acquired). The envelope maps 1:1
onto `logos::CallError`'s `{code, message, origin}`.

```cpp
QVariant _result = m_client->invokeRemoteMethod(…, &_err);
if (_err.ok()) logosDispatchRejection(_result, _err);   // <- added
if (err) *err = _err;
else if (!_err.ok()) qWarning() << "FullApi::echoUintList: remote call failed:" << …;
return _result.toList();
```

* **No signature changes and no return-value changes.** A caller that passes `err` now
  sees `code="dispatch_failed"` with the provider's diagnostic and origin; a caller that
  does not gets exactly the value it always got, plus the `qWarning` the wrapper already
  emits for a failed call. The generated header is byte-identical.
* The detector is emitted once per wrapper in an anonymous namespace and matches
  **exactly** — three string fields and that code — for the same reason
  `logos_rpc_status.h`'s `isUnauthorizedSentinel` matches exactly: an `any`/map return
  carrying user data must never false-match.
* The result is now captured for `void` returns too: a void method can be rejected, and
  the rejection object is the only place that says so.
* Emitted only when the contract has ≥1 invokable method (otherwise it is an unused
  function in an anonymous namespace, and such a contract's wrapper stays byte-identical).

## Scope

**Consumer side only.** Q1's provider half — a Qt-typed provider cannot validate the
ELEMENT of a typed numeric array, because a C++ signature spells `[uint]` and `[any]`
alike as `QVariantList` — is explicitly out of scope and untouched; the project decided
Qt-typed PROVIDER hardening is no longer a goal.

The **lp** wrapper is untouched: `makeSourceLp` is unchanged and its generated output is
byte-identical before and after (verified below).

## Verified by running

**1. Real contract + real generated consumer + real provider.** Generated
`full_api_api.{h,cpp}` from `test-fullapi-qtproxy-module/interfaces/full_api.lidl` with
the pre-fix and post-fix generators (`--general-only --api-style qt`), compiled each
verbatim into the same harness, and drove the **prebuilt `test_fullapi_cpp` cdylib**
through its own C ABI (`logos_module_dispatch`) — only the transport hop is stubbed. The
provider's real answer:

```
{"code":"dispatch_failed","message":"expected unsigned integer at arg0[1], got number","origin":"test_fullapi_cpp"}
```

| check | pre-fix | post-fix |
|---|---|---|
| `echoUintList([1,-1,3], &err)` → `err.code` | `''` | `dispatch_failed` |
| … `err.message` | `''` | `expected unsigned integer at arg0[1], got number` |
| … `err.origin` | `''` | `test_fullapi_cpp` |
| returned list | `[]` (indistinguishable) | `[]` **plus a non-ok err** |
| sync call *without* `err`: logged | no | yes |
| async callback: logged | no | yes |
| **control** accepted call `[1,2,3]` clean + round-trips | pass | pass |
| **control** 3-field map with a different `code` is not a rejection, value survives | pass | pass |
| **control** `echoInt(3)` → 3, no error | pass | pass |

Pre-fix: 7 failing checks. Post-fix: 0. The controls pass on **both** arms, so the
harness is not simply "red before, green after".

**2. Unit tests.** Six new `MakeSourceTest` cases. The four positive ones **fail on the
unfixed generator** (`88 QtEmitsRejectionDetector`, `89 QtSyncFoldsRejectionIntoCallError`,
`90 QtVoidReturnStillCapturesResult`, `91 QtAsyncLogsRejection`) and pass after;
`nix build .#tests` is 224/224 green with the fix.

**3. Negative control.** Regenerating the same contract with `--api-style lp` gives
**byte-identical** output before and after. The comparison is not vacuous: `qt` vs `lp`
output differs on the same generator. (Note for anyone repeating this: `--lidl` mode
routes to `experimental/lidl_gen_client.cpp` and **ignores `--api-style`** — a qt-vs-lp
diff run that way is byte-identical for the wrong reason and cannot fail.)


**4. Built through the real build path.** `nix build .#test_fullapi_qtproxy` in
logos-test-modules with `--override-input logos-module-builder/logos-cpp-sdk <this
branch>`. This caught a defect none of the checks above could: `logos_sdk.cpp`
textually `#include`s **every** generated `<dep>_api.cpp`, so a module with more than
one dependency compiles several copies of the detector into ONE translation unit —
`error: redefinition of 'logosDispatchRejection'`. Internal linkage does not help there;
the second commit adds a preprocessor guard, with a unit test that concatenates two
generated wrappers the way the umbrella does. A single-wrapper contract cannot reach
this, which is why generating from one contract and compiling it was not enough.


**5. Real daemon, real transport, real modules.** `test_fullapi_qtproxy`,
`test_fullapi_cpp` and `test_fullapi_rust` built from logos-test-modules with
`--override-input logos-module-builder/logos-cpp-sdk <this branch>`, loaded into a
`logoscore` daemon over LocalSocket/QtRO:

```
call test_fullapi_qtproxy echoUintList json:[1,2,3]    -> {"result":[1,2,3],"status":"ok"}   (no warning)
call test_fullapi_qtproxy echoUintList json:[1,-1,3]   -> {"result":[],"status":"ok"}
daemon.log: [test_fullapi_qtproxy] FullApi::echoUintList: remote call failed:
            "expected unsigned integer at arg0[1], got number"
```

The same three modules built **without** the override (pristine `master` generator), same
daemon, same call: the log shows the identical wrapper call sequence
(`LogosAPIConsumer: Calling invokeRemoteMethod … "echoUintList"` →
`RemoteLogosObject::callMethod`) and then **nothing** — 0 occurrences of
`remote call failed`. So the new line is the fix, not the harness.

The CLI still sees `[]` in both arms because the proxy's forwarding method calls
`p.echoUintList(v)` **without** an `err` out-param and has nowhere to put one in its
`QVariantList` return — see the Q1 follow-up below.

Also checked: the built plugin binary carries the new code — 99 `…Async: remote call
failed` strings post-fix vs 0 pre-fix, and 231 vs 132 warning strings overall.

Both providers produce the same envelope and both are picked up: the Rust provider
answers `{"code":"dispatch_failed","message":"expected integer at arg0[1],
got number","origin":"test_fullapi_rust"}` and the fixed consumer reports it identically.

## Follow-ups (not in this PR)

* **logos-test-modules registry entry Q1** should be updated: the consumer now *reports*
  the rejection, but the matrix cells `hostile/[uint]/negative-element`,
  `hostile/[uint]/fractional-element`, `hostile/[int]/fractional-element` still read `[]`
  through `test_fullapi_qtproxy`, because the proxy's forwarding methods call
  `p.echoUintList(v)` **without** an `err` out-param and have nowhere to put it in their
  own return type. Making those cells answer `dispatch_failed` is a test-modules change
  (propagate the `CallError`), not a generator one.
* **logos-qt-sdk `qt-generator --backend consumer`** emits the same shape of bug:
  `return logos::qt::fromWire<QVariantList>(_r);` with `_err` carrying only transport
  failures. Same fix, different repo.
* The **async** surface still cannot deliver an error to its callback (documented in
  `cpp-generator/docs/project.md`); that needs an API change, not a codegen fix.
