### PR TITLE
fix(generator): one declaration, one binding — optional record fields on the legacy path

### DIFF
--- a/cpp-generator/CMakeLists.txt
+++ b/cpp-generator/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(logos-cpp-generator
     main.cpp
     legacy/main.cpp
     legacy/generator_lib.cpp
+    legacy/lidl_to_json.cpp
     experimental/lidl_emit_common.cpp
     experimental/lidl_gen_client.cpp
     experimental/lidl_gen_cdylib.cpp

--- a/cpp-generator/docs/project.md
+++ b/cpp-generator/docs/project.md
@@ -11,6 +11,7 @@ cpp-generator/
 ├── legacy/                         # Original generator (unchanged from master)
 │   ├── main.cpp                    # legacy_main() — plugin/metadata/provider-header modes
 │   ├── generator_lib.h/cpp         # Shared utilities, type mapping, header parser, umbrella emission
+│   ├── lidl_to_json.h/cpp         # ModuleDecl → the JSON surface generator_lib consumes
 │   └── legacy_main.h              # Forward declaration
 ├── experimental/                   # C++/Qt-specific generator backends
 │   ├── lidl_compat.h              # Bridges the backends onto logos-lidl's std AST
@@ -105,7 +106,9 @@ Per surface:
 |---|---|---|
 | cdylib / std (`lidlTypeToStd`, `lidl_gen_cdylib`) | `std::optional<T>` | encoded by logos-protocol's `Codec<std::optional<T>>`; key omission is the record emitter's job (a codec never sees the slot) |
 | `?any` / `?{tstr: any}` / `?[any]` | `LogosMap` / `LogosList` | collapses: `nlohmann::json` already carries `null`, so wrapping it would make the slot three-state |
-| Qt (`lidlTypeToQt`) | `QVariant` | two-state (an invalid QVariant is Qt's empty inhabitant) but **untyped** — see Known Limitations |
+| Qt (`lidlTypeToQt`, `lidl_gen_client`) | `QVariant` | two-state (an invalid QVariant is Qt's empty inhabitant) but **untyped** — Qt has no optional template |
+| legacy consumer, record **field** (`lidl_to_json` + `generator_lib`) | `QVariant` (Qt) / `std::optional<T>` (Lp) | same answer as the client-stub and cdylib backends respectively; the alias collapse above applies on Lp |
+| legacy consumer, **positional** slot (param, return, event param) | `QVariant` (Qt) / `LogosMap` (Lp) | still flattened — see Known Limitations |
 | header-first (`impl_header_parser`) | `std::optional<T>` ↔ `?T` | `std::optional<std::optional<T>>` has no LIDL type; it collapses to `?T` and is reported on stderr |
 
 ### Client stubs (`lidl_gen_client.h/cpp`)
@@ -305,17 +308,23 @@ Fixture files in `tests/experimental/fixtures/`:
 - LIDL does not support generic/parameterized types or inheritance
 - `--from-header` emits the **cdylib** backend here (the `qt` glue backend moved to logos-qt-generator); the **Rust** backend lives in logos-rust-sdk's `lidl-gen`, generating over logos-lidl's C ABI
 - Client stub generation (`lidlMakeHeader`/`lidlMakeSource`) is only available from LIDL files, not from `--from-header`
-- **Optionality is untyped on the Qt/Lp consumer surface.** The consumer wrappers real
-  modules get come from `legacy/main.cpp` → `generateInterfaceWrappers` → `generator_lib`,
-  and the AST is flattened to a single Qt **type-name string** per slot at
-  `moduleMethodsToJson` / `moduleRecordsToJson` / `moduleEventsToJson` — a boundary that
-  optionality (like nesting, map key types and descriptions) cannot cross. `?T` therefore
-  arrives as `QVariant`: the right *shape* (an invalid QVariant is Qt's empty inhabitant,
-  and the wire's `null` becomes exactly that) with no *type*, so a consumer gets no
-  compile-time check and cannot tell `?tstr` from `?uint` or recover a `?Record`'s struct.
-  Carrying it further means widening that JSON surface with a per-slot optional flag and
-  teaching both the Qt and Lp emitters to honour it. Until then the generator prints a
-  `Note:` naming every flattened slot, so an affected build is never silent.
+- **Optionality is still untyped in *positional* slots on the legacy consumer path.** The
+  consumer wrappers real modules get come from `legacy/main.cpp` →
+  `generateInterfaceWrappers` → `lidl_to_json` → `generator_lib`, and that JSON boundary
+  carries a single Qt **type-name string** per slot. Record *fields* now carry an
+  `optional` flag alongside the value type, so both LIDL spellings emit identical, typed
+  code (`QVariant` on Qt, `std::optional<T>` on Lp). A **method parameter, a return type
+  and an event parameter still do not**: they arrive as `QVariant` (Qt) / `LogosMap` (Lp)
+  — the right *shape* (an invalid QVariant / a JSON `null` is the empty inhabitant) with
+  no *type*, so a caller gets no compile-time check and cannot tell `?tstr` from `?uint`
+  or recover a `?Record`'s struct. There is no spelling divergence there — a positional
+  slot has no name to hang a flag on, so it only ever had the type-kind form — and closing
+  it changes generated method **signatures**, i.e. a source break for every existing call
+  site. Until then the generator prints a `Note:` naming every still-flattened slot, so an
+  affected build is never silent. `OptionalSpellings.PositionalSlotsAreStillFlattened`
+  pins the current behaviour so closing the gap is a deliberate change.
+- **Nesting, map key types and descriptions still do not cross that boundary either** —
+  the flag added for optionality is per-field, not a general widening.
 - `lidlRecordCollidesWithBytesTag` reads *through* an optional (via `fieldValueType`), so a
   single-`_bytes`-field record is refused under both spellings. It used to read `f.type`,
   which refused `? _bytes: tstr` and let `_bytes: ?tstr` through — the same declaration,

--- a/cpp-generator/legacy/generator_lib.cpp
+++ b/cpp-generator/legacy/generator_lib.cpp
@@ -162,9 +162,19 @@ static QString mapReturnTypeStd(const QString& qtType)
 // `InfoModule::Status` — because one module consuming two deps that each
 // declare `Status` includes both wrappers into the same translation unit.
 //
-// An empty record set leaves every emission path byte-for-byte as it was.
+// A field object carries an optional third key, `"optional"`. It is NOT a type
+// name — it cannot be, because neither surface's type name can express `?T` the
+// same way: Qt has no optional template and the std one does. `"type"` is
+// always the VALUE type (optionality stripped) and `"optional"` says whether the
+// slot may be empty, so the two LIDL spellings of one declaration (`? name: T`
+// and `name: ?T`) arrive here as the same object and leave as the same code.
+// The metaobject-introspection path never sets it; false is the historical
+// behaviour.
+//
+// An empty record set leaves every emission path byte-for-byte as it was, and so
+// does a record set in which nothing is optional.
 
-struct RecordField { QString name; QString type; };
+struct RecordField { QString name; QString type; bool optional = false; };
 struct RecordDef   { QString name; QVector<RecordField> fields; };
 using RecordSet = QVector<RecordDef>;
 
@@ -187,6 +197,7 @@ static RecordSet parseRecords(const QJsonArray& records)
             RecordField f;
             f.name = fo.value("name").toString();
             f.type = fo.value("type").toString();
+            f.optional = fo.value("optional").toBool();
             if (f.name.isEmpty()) continue;
             def.fields.append(f);
         }
@@ -371,6 +382,70 @@ static QString fromWireFor(const QString& qtType, ApiStyle style, const RecordSe
     return toQVariantConversion(mapParamType(qtType), wire);
 }
 
+// ─── Optional record fields ──────────────────────────────────────────────
+//
+// `?T` is TWO-state: a value of T, or empty — never three. Each surface has
+// exactly ONE empty inhabitant to spell that with, and they are different
+// inhabitants, so the two surfaces answer differently:
+//
+//   Qt  — QVariant. Qt has no optional template; an INVALID QVariant is its
+//         empty inhabitant. The value type is lost (a consumer cannot tell
+//         `?tstr` from `?uint`), which is the same answer the experimental
+//         client-stub backend gives for the same surface — see
+//         lidl_gen_client.cpp's lidlFieldTypeQt. Deliberately identical: two
+//         Qt consumer generators disagreeing about one contract is the bug
+//         class this whole change is about.
+//
+//   Lp  — std::optional<T>, so the std surface KEEPS the value type.
+//         std::nullopt is C++'s single empty inhabitant, and the encoder that
+//         pairs with it is logos-protocol's Codec<std::optional<T>>. Same
+//         answer the cdylib backend gives (lidlFieldTypeCdylib).
+//
+// EXCEPT over the untyped-JSON aliases, on the Lp surface only: LogosMap and
+// LogosList are nlohmann::json, and json already has `null` among its
+// inhabitants, so std::optional<LogosMap> would give `?any` TWO empty
+// spellings and make it three-state. `?any` / `?{K:V}` / `?[any]` therefore
+// collapse onto the bare alias — same two states, one C++ type. (Again the
+// cdylib rule, verbatim.)
+static bool lpAliasIsAlreadyNullable(const QString& lpType)
+{
+    return lpType == "LogosMap" || lpType == "LogosList";
+}
+
+// The C++ spelling of a record FIELD. Non-optional fields go through
+// paramTypeFor unchanged, so a contract that declares no optional emits
+// byte-for-byte what it emitted before.
+static QString fieldTypeFor(const RecordField& f, ApiStyle style, const RecordSet& rs)
+{
+    const QString value = paramTypeFor(f.type, style, rs);
+    if (!f.optional) return value;
+    if (style == ApiStyle::Qt) return QStringLiteral("QVariant");
+    if (lpAliasIsAlreadyNullable(value)) return value;
+    return "std::optional<" + value + ">";
+}
+
+// True when some field actually materialises a std::optional on the Lp surface
+// — gates the generated `#include <optional>`, so a contract with no optional
+// (or one whose only optionals are untyped-JSON aliases) keeps its header
+// byte-for-byte unchanged.
+static bool recordsUseStdOptional(const RecordSet& rs)
+{
+    for (const RecordDef& d : rs)
+        for (const RecordField& f : d.fields)
+            if (f.optional && !lpAliasIsAlreadyNullable(paramTypeFor(f.type, ApiStyle::Lp, rs)))
+                return true;
+    return false;
+}
+
+// Whether an optional field is carried in a std::optional (as opposed to an
+// alias that is already nullable, or the Qt surface's QVariant). Decides which
+// encode/decode shape the conversions below emit.
+static bool fieldIsWrappedOptional(const RecordField& f, ApiStyle style, const RecordSet& rs)
+{
+    return f.optional && style == ApiStyle::Lp
+        && !lpAliasIsAlreadyNullable(paramTypeFor(f.type, style, rs));
+}
+
 // The struct declarations, emitted inside the wrapper class.
 static void emitRecordStructs(QTextStream& s, const RecordSet& rs, ApiStyle style)
 {
@@ -379,7 +454,7 @@ static void emitRecordStructs(QTextStream& s, const RecordSet& rs, ApiStyle styl
     for (const RecordDef& d : rs) {
         s << "    struct " << d.name << " {\n";
         for (const RecordField& f : d.fields)
-            s << "        " << paramTypeFor(f.type, style, rs) << " " << f.name << "{};\n";
+            s << "        " << fieldTypeFor(f, style, rs) << " " << f.name << "{};\n";
         s << "    };\n";
     }
     s << "\n";
@@ -409,13 +484,35 @@ static void emitRecordConversions(QTextStream& s, const RecordSet& rs, ApiStyle 
           << "(const " << qual << d.name << "& v) {\n";
         if (style == ApiStyle::Lp) {
             s << "    nlohmann::json __j = nlohmann::json::object();\n";
-            for (const RecordField& f : d.fields)
+            for (const RecordField& f : d.fields) {
+                if (fieldIsWrappedOptional(f, style, rs)) {
+                    // A record field is a NAMED slot, so empty is spelled by
+                    // OMITTING the key — never by writing null. (A positional
+                    // slot has no key to omit and writes null instead; arity
+                    // must never change.) The round trip is therefore
+                    // canonicalising, not identity: a peer that sent
+                    // `"f": null` gets the key back omitted, and both spellings
+                    // decode to the same single empty state.
+                    s << "    if (v." << f.name << ".has_value()) __j[\"" << f.name << "\"] = "
+                      << toWireFor(f.type, style, rs, "(*v." + f.name + ")") << ";\n";
+                    continue;
+                }
                 s << "    __j[\"" << f.name << "\"] = "
                   << toWireFor(f.type, style, rs, "v." + f.name) << ";\n";
+            }
             s << "    return __j;\n";
         } else {
             s << "    QVariantMap __m;\n";
             for (const RecordField& f : d.fields) {
+                if (f.optional) {
+                    // Same named-slot rule on the Qt surface: an INVALID
+                    // QVariant is empty, and empty omits the key. Inserting it
+                    // would encode `"f": null`, which is the positional
+                    // spelling.
+                    s << "    if (v." << f.name << ".isValid()) __m.insert(QStringLiteral(\""
+                      << f.name << "\"), v." << f.name << ");\n";
+                    continue;
+                }
                 // Qt's surface type IS the wire type for non-record fields, so
                 // fromValue is what puts it in the map; records/containers
                 // already produce a QVariant-compatible value.
@@ -438,6 +535,16 @@ static void emitRecordConversions(QTextStream& s, const RecordSet& rs, ApiStyle 
             s << "    if (!w.is_object()) return __out;\n";
             for (const RecordField& f : d.fields) {
                 const QString acc = "w.at(\"" + f.name + "\")";
+                if (fieldIsWrappedOptional(f, style, rs)) {
+                    // An absent key and an explicit null are the SAME state on
+                    // decode, so both must leave the field nullopt. Testing
+                    // only `contains` would decode `"f": null` through the
+                    // value conversion and turn empty into a VALUE (0, "").
+                    s << "    if (w.contains(\"" << f.name << "\") && !" << acc
+                      << ".is_null()) __out." << f.name << " = "
+                      << fromWireFor(f.type, style, rs, acc, qual) << ";\n";
+                    continue;
+                }
                 s << "    if (w.contains(\"" << f.name << "\")) __out." << f.name << " = "
                   << fromWireFor(f.type, style, rs, acc, qual) << ";\n";
             }
@@ -445,6 +552,14 @@ static void emitRecordConversions(QTextStream& s, const RecordSet& rs, ApiStyle 
             s << "    const QVariantMap __m = w.toMap();\n";
             for (const RecordField& f : d.fields) {
                 const QString acc = "__m.value(QStringLiteral(\"" + f.name + "\"))";
+                if (f.optional) {
+                    // Absent and null both arrive as an INVALID QVariant — the
+                    // same state, as the contract requires. Converting (a
+                    // `.toString()` on an optional `tstr`) would have turned
+                    // empty into "", which is a value.
+                    s << "    __out." << f.name << " = " << acc << ";\n";
+                    continue;
+                }
                 s << "    __out." << f.name << " = "
                   << fromWireFor(f.type, style, rs, acc, qual) << ";\n";
             }
@@ -1062,6 +1177,9 @@ QString makeHeaderLp(const QString& moduleName, const QString& className, const 
     s << "#include <cstdint>\n";
     s << "#include <string>\n";
     s << "#include <vector>\n";
+    // Only when a field actually materialises one, so a contract with no
+    // optional keeps its header byte-for-byte unchanged.
+    if (recordsUseStdOptional(rs)) s << "#include <optional>\n";
     s << "#include <functional>\n";
     s << "#include <nlohmann/json.hpp>\n";
     s << "#include \"logos_json.h\"\n";

--- a/cpp-generator/legacy/lidl_to_json.cpp
+++ b/cpp-generator/legacy/lidl_to_json.cpp
@@ -1,0 +1,148 @@
+#include "lidl_to_json.h"
+
+#include <QJsonObject>
+#include <QStringList>
+
+#include "../experimental/lidl_emit_common.h"   // lidlTypeToQt — the one Qt type mapper
+
+// Convert a TypeExpr → Qt-typed string name (same surface the
+// metaobject-introspection path produces for methods, so generator_lib
+// can consume both via one code path).
+//
+// ONE Qt type mapper. This used to be a near-duplicate of `lidlTypeToQt`
+// (experimental/lidl_emit_common.cpp) and the two disagreed: this copy had no
+// `void` case, so a `-> void` method reaching it as Primitive("void") from the
+// impl-header parser fell through to QVariant and generated
+// `QVariant doVoid(...)`. (The .lidl parser spells the same thing
+// Named("void"), which survived only by accident — mapReturnType's
+// `base == "void"` early-out.) The lp/std tables are DERIVED from this name, so
+// the same bug produced `LogosMap doVoid(...)` on the Qt-free surface: not a
+// Qt-only defect, a front-end one. It is now a delegation, so there is one
+// table to disagree with.
+QString lidlTypeExprToQtTypeName(const TypeExpr& te)
+{
+    return lidlTypeToQt(te);
+}
+
+// Report every optional slot this path still flattens into a bare type name.
+//
+// A record FIELD no longer does: moduleRecordsToJson below carries `optional`
+// alongside the value type, and the emitter reconstitutes it (QVariant on the
+// Qt surface, std::optional<T> on the Lp one). What is still flattened is every
+// POSITIONAL slot — a method parameter, a return type, an event parameter.
+// Those have no name to hang a flag on, so they only ever had the type-kind
+// spelling and there is no spelling divergence to fix; what they lose is the
+// value TYPE, exactly as `lidlTypeToQt` documents (`?T` -> QVariant, and via
+// the derived std table -> LogosMap). Two-stateness survives — an invalid
+// QVariant / a JSON null is the empty inhabitant — but the consumer gets no
+// compile-time check on the value and cannot tell `?tstr` from `?uint`.
+//
+// Widening those means changing the generated method SIGNATURES, which is a
+// source break for every existing caller and buys nothing for the
+// one-declaration-two-spellings rule. So they stay flattened, and say so.
+void noteOptionalPositionalSlots(const ModuleDecl& mod, const QString& where,
+                                 QTextStream& err)
+{
+    QStringList optSlots;
+    for (const MethodDecl& md : mod.methods) {
+        for (const ParamDecl& pd : md.params)
+            if (paramIsOptional(pd))
+                optSlots << (qs(md.name) + "(" + qs(pd.name) + ")");
+        if (typeIsOptional(md.returnType))
+            optSlots << (qs(md.name) + "() return");
+    }
+    for (const EventDecl& ed : mod.events)
+        for (const ParamDecl& pd : ed.params)
+            if (paramIsOptional(pd))
+                optSlots << (qs(ed.name) + "(" + qs(pd.name) + ")");
+    if (optSlots.isEmpty()) return;
+    err << "Note: " << where << ": optional positional slot(s) ["
+        << optSlots.join(", ")
+        << "] are generated as untyped QVariant (LogosMap on the lp surface). A "
+           "positional slot has no name to carry an optional flag, so `?T` keeps "
+           "its two states (an invalid QVariant / a JSON null is the empty one) "
+           "but loses T. Record fields are unaffected — they carry optionality "
+           "through.\n";
+}
+
+// Build a getMethods()-shaped QJsonArray (the surface makeHeader/makeSource
+// consume) from a parsed ModuleDecl. Every interface method is invokable.
+QJsonArray moduleMethodsToJson(const ModuleDecl& mod)
+{
+    QJsonArray arr;
+    for (const MethodDecl& m : mod.methods) {
+        QJsonObject o;
+        o["name"] = qs(m.name);
+        o["returnType"] = lidlTypeExprToQtTypeName(m.returnType);
+        o["isInvokable"] = true;
+        QJsonArray params;
+        for (const ParamDecl& p : m.params) {
+            QJsonObject po;
+            po["type"] = lidlTypeExprToQtTypeName(p.type);
+            po["name"] = qs(p.name);
+            params.append(po);
+        }
+        o["parameters"] = params;
+        arr.append(o);
+    }
+    return arr;
+}
+
+// Build the records QJsonArray ({ name, fields:[{name,type,optional}] }) from a
+// parsed ModuleDecl — the contract's `type Foo { ... }` declarations, which
+// generator_lib turns into structs nested in the wrapper class.
+//
+// OPTIONALITY SURVIVES HERE, and it is the whole reason this object has three
+// keys instead of two. A field has two equivalent spellings — the flag
+// (`? name: T`) and the type kind (`name: ?T`) — which logos-lidl's docs/spec.md
+// binds to ONE meaning and requires to produce byte-identical code. Flattening
+// `fd.type` into a name answered that question two different ways from one
+// contract: the flag spelling kept T (so `? maybe: tstr` became a bare `QString`
+// that cannot be empty at all, silently defaulting), the type spelling collapsed
+// to QVariant. Both answers came from reading the verbatim spelling instead of
+// asking.
+//
+// So: `type` is the value type with optionality stripped (fieldValueType), and
+// `optional` is true for either spelling (fieldIsOptional). Those accessors are
+// the frontend's, and are the ONLY correct source — `fd.optional` alone and
+// `fd.type.kind == Optional` alone are the same bug from opposite sides.
+QJsonArray moduleRecordsToJson(const ModuleDecl& mod)
+{
+    QJsonArray arr;
+    for (const TypeDecl& td : mod.types) {
+        QJsonObject o;
+        o["name"] = qs(td.name);
+        QJsonArray fields;
+        for (const FieldDecl& fd : td.fields) {
+            QJsonObject f;
+            f["name"] = qs(fd.name);
+            f["type"] = lidlTypeExprToQtTypeName(fieldValueType(fd));
+            f["optional"] = fieldIsOptional(fd);
+            fields.append(f);
+        }
+        o["fields"] = fields;
+        arr.append(o);
+    }
+    return arr;
+}
+
+// Build the events QJsonArray ({ name, params:[{name,type}] }) — same shape
+// loadEventsFromLidl produces — from a parsed ModuleDecl.
+QJsonArray moduleEventsToJson(const ModuleDecl& mod)
+{
+    QJsonArray arr;
+    for (const EventDecl& ed : mod.events) {
+        QJsonObject o;
+        o["name"] = qs(ed.name);
+        QJsonArray params;
+        for (const ParamDecl& pd : ed.params) {
+            QJsonObject p;
+            p["name"] = qs(pd.name);
+            p["type"] = lidlTypeExprToQtTypeName(pd.type);
+            params.append(p);
+        }
+        o["params"] = params;
+        arr.append(o);
+    }
+    return arr;
+}

--- a/cpp-generator/legacy/lidl_to_json.h
+++ b/cpp-generator/legacy/lidl_to_json.h
@@ -1,0 +1,49 @@
+#ifndef LIDL_TO_JSON_H
+#define LIDL_TO_JSON_H
+
+// THE BOUNDARY between the LIDL frontend and the legacy consumer emitter.
+//
+// generator_lib (makeHeader / makeSource / makeHeaderLp / makeSourceLp)
+// consumes a JSON surface, not an AST — because the same emitter also serves
+// the metaobject-introspection path, which has only Qt type NAMES to offer.
+// These three functions are the only place a `ModuleDecl` is turned into that
+// surface, so they are the only place a property of a TypeExpr can be lost.
+//
+// They live in their own translation unit rather than inside `main.cpp` so the
+// conversion is linkable, and therefore testable: the rule that the two LIDL
+// optionality spellings must emit byte-identical code is a property of
+// (frontend -> JSON -> emitter) end to end, and cannot be asserted on either
+// half alone.
+
+#include <QJsonArray>
+#include <QString>
+#include <QTextStream>
+
+#include "../experimental/lidl_compat.h"
+
+// A TypeExpr -> the Qt type NAME the emitter keys off. One Qt type mapper:
+// this delegates to `lidlTypeToQt` (experimental/lidl_emit_common.cpp) rather
+// than keeping a second table.
+QString lidlTypeExprToQtTypeName(const TypeExpr& te);
+
+// getMethods()-shaped: [ { name, returnType, isInvokable, parameters:[{name,type}] } ]
+QJsonArray moduleMethodsToJson(const ModuleDecl& mod);
+
+// [ { name, fields: [ { name, type, optional } ] } ]
+//
+// `type` is the Qt name of the field's VALUE type (optionality stripped) and
+// `optional` is the answer for BOTH spellings — `? name: T` and `name: ?T`
+// produce the identical object here, which is what makes the emitted code
+// identical. Read via fieldIsOptional()/fieldValueType(); never re-derived.
+QJsonArray moduleRecordsToJson(const ModuleDecl& mod);
+
+// [ { name, params: [ { name, type } ] } ]
+QJsonArray moduleEventsToJson(const ModuleDecl& mod);
+
+// Report the optional slots this path still flattens — the POSITIONAL ones
+// (method parameters, return types, event parameters). Record fields are no
+// longer among them: they carry `optional` through the JSON above.
+void noteOptionalPositionalSlots(const ModuleDecl& mod, const QString& where,
+                                 QTextStream& err);
+
+#endif // LIDL_TO_JSON_H

--- a/cpp-generator/legacy/main.cpp
+++ b/cpp-generator/legacy/main.cpp
@@ -19,7 +19,7 @@
 #include "metadata_dependencies.h"
 #include "../experimental/lidl_compat.h"
 #include "../experimental/impl_header_parser.h"
-#include "../experimental/lidl_emit_common.h"   // lidlTypeToQt — the one Qt type mapper
+#include "lidl_to_json.h"   // ModuleDecl -> the JSON surface generator_lib consumes
 
 // Escape a string for safe embedding inside a generated C++ string literal.
 static QString cppStringEscape(const QString& s)
@@ -30,73 +30,6 @@ static QString cppStringEscape(const QString& s)
     out.replace('\n', "\\n");
     return out;
 }
-
-// Convert a TypeExpr → Qt-typed string name (same surface the
-// metaobject-introspection path produces for methods, so generator_lib
-// can consume both via one code path).
-//
-// ONE Qt type mapper. This used to be a near-duplicate of `lidlTypeToQt`
-// (experimental/lidl_emit_common.cpp) and the two disagreed: this copy had no
-// `void` case, so a `-> void` method reaching it as Primitive("void") from the
-// impl-header parser fell through to QVariant and generated
-// `QVariant doVoid(...)`. (The .lidl parser spells the same thing
-// Named("void"), which survived only by accident — mapReturnType's
-// `base == "void"` early-out.) The lp/std tables are DERIVED from this name, so
-// the same bug produced `LogosMap doVoid(...)` on the Qt-free surface: not a
-// Qt-only defect, a front-end one. It is now a delegation, so there is one
-// table to disagree with.
-static QString lidlTypeExprToQtTypeName(const TypeExpr& te)
-{
-    return lidlTypeToQt(te);
-}
-
-// Report every optional slot this path is about to flatten.
-//
-// THE BOUNDARY. Everything below (moduleMethodsToJson / moduleRecordsToJson /
-// moduleEventsToJson -> generator_lib) consumes a single Qt TYPE-NAME STRING per
-// slot. A TypeExpr's optionality — like its nesting, its map key type and its
-// descriptions — does not survive being turned into a name, and Qt has no name
-// to survive as: there is no metatype for an optional, so the mapper answers
-// QVariant (see lidlTypeToQt).
-//
-// That leaves a Qt/Lp consumer of an optional slot with the right SHAPE and no
-// TYPE: an invalid QVariant is Qt's empty inhabitant, so two-stateness survives,
-// but the consumer gets no compile-time check on the value and cannot tell
-// `?tstr` from `?uint` or recover a `?Record`'s struct. Carrying optionality
-// past this point means widening the JSON surface these three functions produce
-// and teaching generator_lib a per-slot optional flag on both the Qt and Lp
-// emitters — real work, and not what this change is.
-//
-// So it stays flattened, and says so. Silence here is what made the gap easy to
-// miss in the first place; a build that generates a Qt consumer for an optional
-// contract should not look like a build that had nothing to lose.
-static void noteOptionalFlattened(const ModuleDecl& mod, const QString& where,
-                                  QTextStream& err)
-{
-    QStringList optSlots;
-    for (const TypeDecl& td : mod.types)
-        for (const FieldDecl& fd : td.fields)
-            if (fieldIsOptional(fd))
-                optSlots << (qs(td.name) + "." + qs(fd.name));
-    for (const MethodDecl& md : mod.methods) {
-        for (const ParamDecl& pd : md.params)
-            if (paramIsOptional(pd))
-                optSlots << (qs(md.name) + "(" + qs(pd.name) + ")");
-        if (typeIsOptional(md.returnType))
-            optSlots << (qs(md.name) + "() return");
-    }
-    for (const EventDecl& ed : mod.events)
-        for (const ParamDecl& pd : ed.params)
-            if (paramIsOptional(pd))
-                optSlots << (qs(ed.name) + "(" + qs(pd.name) + ")");
-    if (optSlots.isEmpty()) return;
-    err << "Note: " << where << ": optional slot(s) [" << optSlots.join(", ")
-        << "] are generated as untyped QVariant. The Qt/Lp consumer surface has "
-           "no optional type, so `?T` keeps its two states (an invalid QVariant "
-           "is the empty one) but loses T.\n";
-}
-
-static QJsonArray moduleRecordsToJson(const ModuleDecl& mod);
 
 // Load events from a `.lidl` sidecar shipped alongside a module's
 // pre-built headers. Returns a JSON array of
@@ -122,22 +55,9 @@ static QJsonArray loadEventsFromLidl(const QString& lidlPath, QTextStream& err,
         return result;
     }
 
-    noteOptionalFlattened(pr.module, lidlPath, err);
+    noteOptionalPositionalSlots(pr.module, lidlPath, err);
     if (outRecords) *outRecords = moduleRecordsToJson(pr.module);
-    for (const EventDecl& ed : pr.module.events) {
-        QJsonObject obj;
-        obj["name"] = qs(ed.name);
-        QJsonArray params;
-        for (const ParamDecl& pd : ed.params) {
-            QJsonObject p;
-            p["name"] = qs(pd.name);
-            p["type"] = lidlTypeExprToQtTypeName(pd.type);
-            params.append(p);
-        }
-        obj["params"] = params;
-        result.append(obj);
-    }
-    return result;
+    return moduleEventsToJson(pr.module);
 }
 
 // ── Dependency interfaces ───────────────────────────────────────────────────
@@ -190,72 +110,6 @@ static QVector<InterfaceSpec> parseSpecFlags(const QStringList& args, const QStr
         specs.append(spec);
     }
     return specs;
-}
-
-// Build a getMethods()-shaped QJsonArray (the surface makeHeader/makeSource
-// consume) from a parsed ModuleDecl. Every interface method is invokable.
-static QJsonArray moduleMethodsToJson(const ModuleDecl& mod)
-{
-    QJsonArray arr;
-    for (const MethodDecl& m : mod.methods) {
-        QJsonObject o;
-        o["name"] = qs(m.name);
-        o["returnType"] = lidlTypeExprToQtTypeName(m.returnType);
-        o["isInvokable"] = true;
-        QJsonArray params;
-        for (const ParamDecl& p : m.params) {
-            QJsonObject po;
-            po["type"] = lidlTypeExprToQtTypeName(p.type);
-            po["name"] = qs(p.name);
-            params.append(po);
-        }
-        o["parameters"] = params;
-        arr.append(o);
-    }
-    return arr;
-}
-
-// Build the records QJsonArray ({ name, fields:[{name,type}] }) from a parsed
-// ModuleDecl — the contract's `type Foo { ... }` declarations, which
-// generator_lib turns into structs nested in the wrapper class.
-static QJsonArray moduleRecordsToJson(const ModuleDecl& mod)
-{
-    QJsonArray arr;
-    for (const TypeDecl& td : mod.types) {
-        QJsonObject o;
-        o["name"] = qs(td.name);
-        QJsonArray fields;
-        for (const FieldDecl& fd : td.fields) {
-            QJsonObject f;
-            f["name"] = qs(fd.name);
-            f["type"] = lidlTypeExprToQtTypeName(fd.type);
-            fields.append(f);
-        }
-        o["fields"] = fields;
-        arr.append(o);
-    }
-    return arr;
-}
-
-// Build the events QJsonArray ({ name, params:[{name,type}] }) — same shape
-// loadEventsFromLidl produces — from a parsed ModuleDecl.
-static QJsonArray moduleEventsToJson(const ModuleDecl& mod)
-{
-    QJsonArray arr;
-    for (const EventDecl& ed : mod.events) {
-        QJsonObject o;
-        o["name"] = qs(ed.name);
-        QJsonArray params;
-        for (const ParamDecl& pd : ed.params) {
-            QJsonObject p;
-            p["name"] = qs(pd.name);
-            p["type"] = lidlTypeExprToQtTypeName(pd.type);
-            params.append(p);
-        }
-        o["params"] = params;
-        arr.append(o);
-    }
-    return arr;
 }
 
 // Parse an interface definition file into a ModuleDecl. `.lidl` parses
@@ -347,7 +201,7 @@ static bool generateInterfaceWrappers(const QVector<InterfaceSpec>& ifaces,
             }
         }
 
-        noteOptionalFlattened(mod, spec.path, err);
+        noteOptionalPositionalSlots(mod, spec.path, err);
 
         const QString className = toPascalCase(spec.name);
         const QJsonArray methods = moduleMethodsToJson(mod);

--- a/tests/generator/CMakeLists.txt
+++ b/tests/generator/CMakeLists.txt
@@ -1,5 +1,13 @@
+# logos-lidl: test_optional_spellings runs the LEGACY path end to end — LIDL
+# text -> the JSON surface (lidl_to_json) -> the emitter — because the rule it
+# asserts (the two optionality spellings emit identical code) is a property of
+# that composition and cannot be checked on either half alone.
+find_package(logos-lidl REQUIRED)
+
 add_executable(generator_tests
     ${CMAKE_CURRENT_SOURCE_DIR}/../../cpp-generator/legacy/generator_lib.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../cpp-generator/legacy/lidl_to_json.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../cpp-generator/experimental/lidl_emit_common.cpp
     test_to_pascal_case.cpp
     test_normalize_type.cpp
     test_map_param_type.cpp
@@ -10,17 +18,20 @@ add_executable(generator_tests
     test_make_umbrella.cpp
     test_parse_provider_header.cpp
     test_records.cpp
+    test_optional_spellings.cpp
 )
 
 target_include_directories(generator_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../cpp-generator
     ${CMAKE_CURRENT_SOURCE_DIR}/../../cpp-generator/legacy
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../cpp-generator/experimental
     ${CMAKE_CURRENT_SOURCE_DIR}/../../cpp
 )
 
 target_link_libraries(generator_tests PRIVATE
     GTest::gtest_main
     Qt${QT_VERSION_MAJOR}::Core
+    logos-lidl::logos_lidl
 )
 
 gtest_discover_tests(generator_tests)

--- a/tests/generator/test_optional_spellings.cpp
+++ b/tests/generator/test_optional_spellings.cpp
@@ -1,0 +1,252 @@
+// One declaration, two spellings, one binding.
+//
+// A LIDL record field may be marked optional two ways — the field flag
+// (`? name: T`) and the type kind (`name: ?T`) — and logos-lidl's docs/spec.md
+// binds them to ONE meaning: "They are identical in meaning and MUST produce
+// byte-identical generated code."
+//
+// The legacy consumer path is the one every real C++ module builds through
+// (`--dep <name>=<lidl>`), and it did not honour that. It flattened each
+// TypeExpr into a single Qt type NAME before the emitter saw it, which answers
+// the optionality question by reading the verbatim spelling: the flag form kept
+// T (so `? maybe: tstr` became a bare `QString` that has no empty inhabitant at
+// all and silently defaults to "") while the type form collapsed to QVariant.
+// One contract, two bindings — and the flag form is the one production
+// contracts use.
+//
+// These tests run the whole path, LIDL text -> JSON surface -> emitted code,
+// because the invariant is a property of the composition: neither half can be
+// asserted alone. They are written to fail loudly if the two spellings are ever
+// reconciled by making BOTH of them wrong, which a pure equality assertion
+// would happily accept — see OptionalityActuallySurvives*.
+
+#include <gtest/gtest.h>
+
+#include "generator_lib.h"
+#include "lidl_to_json.h"
+
+namespace {
+
+// The same contract twice: flag spelling, then type-kind spelling. Every
+// round-trippable shape, plus a record, a list of records, and the untyped
+// carriers (`any`, `{tstr: any}`) that must NOT gain a second empty state.
+const char* kFlagSpelling = R"LIDL(
+module probe {
+  version "0.1.0"
+  type Inner {
+    x: int
+  }
+  type Rec {
+    always: tstr
+    ? maybe: tstr
+    ? count: uint
+    ? blob: bstr
+    ? nested: Inner
+    ? items: [tstr]
+    ? recs: [Inner]
+    ? amap: {tstr: any}
+    ? anyv: any
+  }
+  method get() -> Rec
+  event changed(r: Rec)
+}
+)LIDL";
+
+const char* kTypeSpelling = R"LIDL(
+module probe {
+  version "0.1.0"
+  type Inner {
+    x: int
+  }
+  type Rec {
+    always: tstr
+    maybe: ?tstr
+    count: ?uint
+    blob: ?bstr
+    nested: ?Inner
+    items: ?[tstr]
+    recs: ?[Inner]
+    amap: ?{tstr: any}
+    anyv: ?any
+  }
+  method get() -> Rec
+  event changed(r: Rec)
+}
+)LIDL";
+
+// Same contract with nothing optional — the control that the change is inert
+// for every contract that does not use the feature.
+const char* kNoOptional = R"LIDL(
+module probe {
+  version "0.1.0"
+  type Inner {
+    x: int
+  }
+  type Rec {
+    always: tstr
+    maybe: tstr
+  }
+  method get() -> Rec
+  event changed(r: Rec)
+}
+)LIDL";
+
+ModuleDecl parseOrDie(const char* src)
+{
+    LidlParseResult pr = lidlParse(QString::fromUtf8(src));
+    EXPECT_FALSE(pr.hasError()) << pr.error << " (line " << pr.errorLine << ")";
+    return pr.module;
+}
+
+struct Emitted { QString header; QString source; };
+
+Emitted emitFor(const char* lidl, ApiStyle style)
+{
+    const ModuleDecl mod = parseOrDie(lidl);
+    const QJsonArray methods = moduleMethodsToJson(mod);
+    const QJsonArray events  = moduleEventsToJson(mod);
+    const QJsonArray records = moduleRecordsToJson(mod);
+    Emitted e;
+    e.header = makeHeader("probe", "Probe", methods, style, events, BindMode::Static, records);
+    e.source = makeSource("probe", "Probe", "probe_api.h", methods, style, events,
+                          BindMode::Static, records);
+    return e;
+}
+
+} // namespace
+
+// The invariant, stated where it is actually decided: the two spellings reach
+// the emitter as the SAME object. Everything downstream follows from this, and
+// a failure here localises the bug to the boundary rather than the emitter.
+TEST(OptionalSpellings, BoundaryJsonIsIdentical)
+{
+    const QJsonArray flag = moduleRecordsToJson(parseOrDie(kFlagSpelling));
+    const QJsonArray type = moduleRecordsToJson(parseOrDie(kTypeSpelling));
+    EXPECT_EQ(flag, type);
+}
+
+TEST(OptionalSpellings, QtOutputIsByteIdentical)
+{
+    const Emitted flag = emitFor(kFlagSpelling, ApiStyle::Qt);
+    const Emitted type = emitFor(kTypeSpelling, ApiStyle::Qt);
+    EXPECT_EQ(flag.header, type.header);
+    EXPECT_EQ(flag.source, type.source);
+}
+
+TEST(OptionalSpellings, LpOutputIsByteIdentical)
+{
+    const Emitted flag = emitFor(kFlagSpelling, ApiStyle::Lp);
+    const Emitted type = emitFor(kTypeSpelling, ApiStyle::Lp);
+    EXPECT_EQ(flag.header, type.header);
+    EXPECT_EQ(flag.source, type.source);
+}
+
+// Equality alone is satisfied by two identically WRONG outputs — e.g. by
+// dropping optionality from both spellings. These pin what the agreed answer
+// has to be.
+//
+// Qt: an invalid QVariant is the surface's single empty inhabitant, so `?T` is
+// QVariant — two-state, untyped. Same answer the client-stub backend gives for
+// the same surface (lidl_gen_client.cpp), deliberately.
+TEST(OptionalSpellings, OptionalityActuallySurvivesOnQt)
+{
+    for (const char* lidl : {kFlagSpelling, kTypeSpelling}) {
+        const Emitted e = emitFor(lidl, ApiStyle::Qt);
+        // The declared type is not the value type — a bare QString could not be
+        // empty at all.
+        EXPECT_TRUE(e.header.contains("QVariant maybe{};")) << e.header.toStdString();
+        EXPECT_TRUE(e.header.contains("QVariant count{};")) << e.header.toStdString();
+        EXPECT_FALSE(e.header.contains("QString maybe{};")) << e.header.toStdString();
+        // A record field is a NAMED slot: empty omits the key.
+        EXPECT_TRUE(e.source.contains("if (v.maybe.isValid()) __m.insert")) << e.source.toStdString();
+        // Absent and null are the same state on decode: no conversion, which
+        // would have turned empty into "".
+        EXPECT_TRUE(e.source.contains(
+            "__out.maybe = __m.value(QStringLiteral(\"maybe\"));")) << e.source.toStdString();
+        // Required fields keep their typed conversion.
+        EXPECT_TRUE(e.source.contains(
+            "__out.always = __m.value(QStringLiteral(\"always\")).toString();")) << e.source.toStdString();
+    }
+}
+
+// Lp: the std surface HAS an optional, so it keeps the value type. Same answer
+// the cdylib backend gives, and the encoder that pairs with it is
+// logos-protocol's Codec<std::optional<T>>.
+TEST(OptionalSpellings, OptionalityActuallySurvivesOnLp)
+{
+    for (const char* lidl : {kFlagSpelling, kTypeSpelling}) {
+        const Emitted e = emitFor(lidl, ApiStyle::Lp);
+        EXPECT_TRUE(e.header.contains("std::optional<std::string> maybe{};")) << e.header.toStdString();
+        EXPECT_TRUE(e.header.contains("std::optional<uint64_t> count{};")) << e.header.toStdString();
+        EXPECT_TRUE(e.header.contains("std::optional<std::vector<uint8_t>> blob{};")) << e.header.toStdString();
+        EXPECT_TRUE(e.header.contains("std::optional<Inner> nested{};")) << e.header.toStdString();
+        EXPECT_TRUE(e.header.contains("std::optional<std::vector<std::string>> items{};")) << e.header.toStdString();
+        EXPECT_TRUE(e.header.contains("std::optional<std::vector<Inner>> recs{};")) << e.header.toStdString();
+        EXPECT_TRUE(e.header.contains("#include <optional>\n")) << e.header.toStdString();
+        // Named slot: empty omits the key; the value is encoded exactly as the
+        // non-optional field would be (bytes still canonically tagged).
+        EXPECT_TRUE(e.source.contains(
+            "if (v.blob.has_value()) __j[\"blob\"] = logos::bytesToJson((*v.blob));")) << e.source.toStdString();
+        // Absent AND explicit null both leave it nullopt. A `contains`-only
+        // guard would decode null through the value conversion and turn empty
+        // into 0 / "".
+        EXPECT_TRUE(e.source.contains(
+            "if (w.contains(\"maybe\") && !w.at(\"maybe\").is_null())")) << e.source.toStdString();
+    }
+}
+
+// `?any`, `?{K:V}` and `?[any]` are carried as nlohmann::json, which ALREADY
+// has null among its inhabitants. Wrapping those in std::optional would give
+// them two distinct empty spellings — three states, which the two-state rule
+// forbids. They collapse onto the bare alias instead. (The cdylib backend makes
+// exactly this exception; the Qt surface needs none, because `any` is QVariant
+// there either way.)
+TEST(OptionalSpellings, UntypedJsonAliasesDoNotGainASecondEmptyState)
+{
+    for (const char* lidl : {kFlagSpelling, kTypeSpelling}) {
+        const Emitted e = emitFor(lidl, ApiStyle::Lp);
+        EXPECT_TRUE(e.header.contains("LogosMap amap{};")) << e.header.toStdString();
+        EXPECT_TRUE(e.header.contains("LogosMap anyv{};")) << e.header.toStdString();
+        EXPECT_FALSE(e.header.contains("std::optional<LogosMap>")) << e.header.toStdString();
+        EXPECT_FALSE(e.header.contains("std::optional<LogosList>")) << e.header.toStdString();
+    }
+}
+
+// A contract that declares no optional must be untouched by all of the above —
+// including the conditional `#include <optional>`, whose whole point is that it
+// is conditional.
+TEST(OptionalSpellings, ContractsWithoutOptionalsAreUnaffected)
+{
+    const Emitted qt = emitFor(kNoOptional, ApiStyle::Qt);
+    EXPECT_TRUE(qt.header.contains("QString maybe{};")) << qt.header.toStdString();
+    EXPECT_TRUE(qt.source.contains(
+        "__out.maybe = __m.value(QStringLiteral(\"maybe\")).toString();")) << qt.source.toStdString();
+    EXPECT_FALSE(qt.source.contains("isValid()) __m.insert")) << qt.source.toStdString();
+
+    const Emitted lp = emitFor(kNoOptional, ApiStyle::Lp);
+    EXPECT_TRUE(lp.header.contains("std::string maybe{};")) << lp.header.toStdString();
+    EXPECT_FALSE(lp.header.contains("std::optional")) << lp.header.toStdString();
+    EXPECT_FALSE(lp.header.contains("#include <optional>")) << lp.header.toStdString();
+    EXPECT_FALSE(lp.source.contains("has_value()")) << lp.source.toStdString();
+}
+
+// A POSITIONAL slot (method parameter, return type, event parameter) has no
+// name to hang a flag on, so it has only the type-kind spelling and there is no
+// divergence to fix — but it is also still flattened to an untyped carrier,
+// which is the part of the gap this change does NOT close. Pinned so the
+// remaining gap is a documented fact rather than an assumption, and so that
+// closing it later is a deliberate, visible change.
+TEST(OptionalSpellings, PositionalSlotsAreStillFlattened)
+{
+    const char* lidl = R"LIDL(
+module probe {
+  version "0.1.0"
+  method echo(v: ?tstr) -> ?tstr
+}
+)LIDL";
+    const Emitted qt = emitFor(lidl, ApiStyle::Qt);
+    EXPECT_TRUE(qt.header.contains("QVariant echo(QVariant v")) << qt.header.toStdString();
+    const Emitted lp = emitFor(lidl, ApiStyle::Lp);
+    EXPECT_TRUE(lp.header.contains("LogosMap echo(const LogosMap& v")) << lp.header.toStdString();
+    EXPECT_FALSE(lp.header.contains("std::optional")) << lp.header.toStdString();
+}


### PR DESCRIPTION
`? maybe: tstr` and `maybe: ?tstr` are **the same declaration**. logos-lidl's `docs/spec.md` says so and requires them to produce byte-identical code, and logos-lidl#7 added `fieldIsOptional()` / `fieldValueType()` precisely so no backend re-derives the answer. The cdylib, client-stub and both Rust backends honour that. The **legacy consumer path** — the one every real C++ module builds through (`logos-cpp-generator --general-only --dep <name>=<lidl>`, from logos-plugin-qt's `buildPlugin.nix`) — did not:

| contract | before, `--api-style qt` | before, `--api-style lp` |
|---|---|---|
| `? maybe: tstr` | `QString maybe{};` / `.value("maybe").toString()` | `std::string maybe{};` |
| `maybe: ?tstr`  | `QVariant maybe{};` / `.value("maybe")` | `LogosMap maybe{};` |

One contract, two bindings, on both surfaces — and neither lp answer is `std::optional`.

**This is not hypothetical.** `logos-chat-module` writes all five of its optionals with the flag spelling (`? nickname`, `? name`, `? description`, `? preview`, `? sender`), so every one of them landed on the branch that silently defaults. A `QString` has no empty inhabitant at all: an absent `nickname` and an empty-string one were the same value by the time the consumer saw them.

## Root cause

`legacy/main.cpp`'s `moduleRecordsToJson` / `moduleMethodsToJson` / `moduleEventsToJson` flatten every `TypeExpr` into a single Qt **type-name string** before `generator_lib` sees it. Answering "is this optional" from a name means answering it from the *verbatim spelling*, which is the one thing the accessors exist to stop.

## What this changes

The **record-field half** of that boundary, and only it. A field object now carries `optional` alongside `type`, where `type` is the value type (`fieldValueType`) and `optional` is true for either spelling (`fieldIsOptional`). Both spellings arrive at the emitter as the same object, so they leave as the same code. Per surface, matching the sibling backend that already serves it:

- **Qt → `QVariant`**, exactly what `lidl_gen_client.cpp` already emits. Qt has no optional template; an invalid `QVariant` is its single empty inhabitant. Two-state, untyped.
- **Lp → `std::optional<T>`**, exactly what `lidl_gen_cdylib.cpp` already emits, encoded by logos-protocol's `Codec<std::optional<T>>`. Keeps the value type.
  `?any` / `?{K:V}` / `?[any]` collapse onto the bare `LogosMap` / `LogosList` — `nlohmann::json` already carries `null`, so wrapping it would give the slot *two* empty spellings, i.e. three states, which the two-state rule forbids. (Same exception the cdylib backend makes.)

Encode **omits the key** when empty (a record field is a *named* slot); decode treats an absent key and an explicit `null` as the same state, so neither turns empty into `""` or `0`. The round trip canonicalises, as the spec requires.

```diff
  struct Rec {
-     QString nickname{};                    // qt, flag spelling — cannot be empty
+     QVariant nickname{};                   // qt, both spellings
-     std::string nickname{};                // lp, flag spelling
+     std::optional<std::string> nickname{}; // lp, both spellings
  };
```

The three boundary functions move to `legacy/lidl_to_json.{h,cpp}`. Not cosmetic: the rule is a property of *frontend → JSON → emitter*, and while they sat in a TU with `main()` no test could observe it.

## What this does NOT change, and why

**Positional slots — method parameters, return types, event parameters — are still flattened** to `QVariant` (Qt) / `LogosMap` (Lp). A positional slot has no name to hang a flag on, so it only ever had the type-kind spelling: there is no spelling divergence there to fix. What it loses is the value *type*. Closing that changes generated method **signatures**, i.e. a source break for every existing call site, for a defect this PR is not about. `OptionalSpellings.PositionalSlotsAreStillFlattened` pins the current behaviour so closing it later is a deliberate, visible change, and the generator still prints a `Note:` naming every slot it flattens. Nesting, map key types and descriptions still do not cross the boundary either — the flag is per-field, not a general widening. Both gaps are written down in `cpp-generator/docs/project.md` under Known Limitations.

Out of scope, reported not fixed: **logos-qt-sdk's `qt-generator` has the same defect** — `lidl_gen_qt_consumer.cpp` reads `f.type` directly for record fields (lines 211/310/322). Separate repo, separate PR.

## Verification

Every check below was **shown to fail when the property does not hold** — a check that cannot fail proves nothing.

| check | result | its control |
|---|---|---|
| Two contracts identical but for the spelling, `--dep`, `--api-style qt` **and** `lp` → byte-identical | pass | the **same** comparison against a generator built from this base **without** the fix reports a difference on both styles |
| Harness sensitivity | — | two contracts differing only in `count: uint` → `count: int` are reported as different, so the compare is not vacuous |
| A contract with **no** optional generates byte-identically to the unpatched generator, both styles | pass | the same compare reports a difference when handed genuinely different output |
| The 5 new assertions | pass with the fix | **fail on this base** with only the extraction grafted in and `generator_lib.cpp` pristine; the 3 control assertions pass on both, which is what makes them controls |
| Generated wrappers compile, both surfaces | pass | probe contracts **and** the real `logos-chat-module` + `test_fullapi_ext_rust` contracts |
| Emitted lp record codec at runtime | pass | empty omits the key; explicit `null` decodes to `nullopt`, not `""`; uint64 above 2^63 survives; `bstr` stays canonically tagged; `{"maybe": null}` re-encodes omitted |
| `nix build .#tests` (107 tests), `nix build .#cpp-generator` | green | |

## Downstream

`logos-chat-ui` is the only in-tree consumer of a contract with optional record fields; it reads the wire objects directly (`obj.value("nickname").toString()`) and never touches the generated struct, so nothing in the workspace compiles against the changed field types. Both real contracts were generated and compiled on both surfaces as part of the verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
