### PR TITLE
chore: pin logos-protocol 0f26ffd, and move CI to Nix 2.35.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v27
+      # v27 pins Nix 2.22.1, which is old enough to mis-evaluate flake input
+      # overrides that newer Nix handles fine (notably nested
+      # `a.inputs.b.inputs.c.follows`, which 2.22 rejects with "cannot find
+      # flake in the flake registries"). v31 pins 2.35.1. Keep this in step
+      # with logos-standalone-app, which already runs v31 for the same reason.
+      - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785523697,
-        "narHash": "sha256-8WdoCJDLNR/aLkcmeY8CeAZlTIN8ulG/7N1ZFEVDdsQ=",
+        "lastModified": 1786030193,
+        "narHash": "sha256-Z5rxmZBMJsNsUSb37ljbDMKrtrds9Enw5oPJcf8wbVU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "3a31c91d1322dae053bbe28b6e3f441fabcc2162",
+        "rev": "0f26ffdeef18fb9582dc0a95e2bee482464da40d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Pins this repo's own `logos-protocol` to **`0f26ffd`** (current protocol master, Aug 6), up from `3a31c91d` (Jul 31), and moves the CI Nix installer from `cachix/install-nix-action@v27` to `@v31`.

## Why

On macOS, two different protocol revisions statically linked into one process get their weak definitions coalesced by dyld, so one image's protocol code silently binds to the other's. This is not a build error — it is a runtime miscompile, and it bites across real ABI changes in this very span of protocol history (`awaitCompletion` gained parameters; `RpcValue`'s variant gained `uint64_t` *in the middle*, renumbering later alternatives). A measurement on a neighbouring repo found 225 shared weak definitions between `ui-host` and a `ui_qml` plugin.

The short-term workaround was a set of `follows` overrides in `logos-module-builder` (#185), but the nested spelling it needs (`a.inputs.b.inputs.c.follows`) cannot be evaluated by Nix 2.22.1, which CI installs. **This PR is the proper fix instead**: each repo pins the current protocol itself, so no override is needed anywhere. This is one of several independent per-repo PRs.

## Span crossed

`3a31c91d1322dae0…` (Jul 31) → `0f26ffdeef18fb95…` (Aug 6) — **2 commits, 17 files, +4135/−70**. Protocol PRs #40 and #41 only. Small and ABI-stable from this repo's point of view; the two ABI changes above are private to the plain transport (`cpp/implementations/plain/`) and source-compatible here — which is exactly what makes the silent-coalescing bug dangerous, since it never shows up at build time.

## Verified

All run locally on `aarch64-darwin` against the **clean committed tree**.

**1. Lock hygiene — the check whose absence let #185 ship a broken flake.** Deleted `flake.lock` entirely and re-locked from scratch. It succeeds and the result is **byte-identical** to the committed lock (verified with a normalised JSON diff), so the pin is reproducible and not an artifact of incremental updating. The lock now contains **exactly one** `logos-protocol` node, at `0f26ffd`; the update produced a clean 3-line diff with no transitive churn.

**2. Tested under the Nix version CI actually uses, not just mine.** My local Nix is 2.32.4, which is neither the old nor the new CI version — #185 passed every local check on 2.32.4 and still failed on CI's 2.22.1, so local-only evidence is not enough here. I built both real CI toolchains from nixpkgs and ran against each:

| Nix | corresponds to | `flake metadata` | eval `packages.x86_64-linux.tests` (CI's platform) | from-scratch re-lock |
|---|---|---|---|---|
| 2.22.1 | `install-nix-action@v27` (current) | resolves, protocol → `0f26ffd` | OK | OK, reproduces committed lock exactly |
| 2.35.1 | `install-nix-action@v31` (this PR) | resolves, protocol → `0f26ffd` | OK | — |

Both versions evaluate the clean tree to the **bit-identical derivation** `7ngppbfq1w6i7hgg9d85am9gcaf6l129-logos-cpp-sdk-tests-0.2.0.drv`, so the installer bump provably changes nothing about what CI builds.

**3. Build and tests — real counts from actual output.** `nix build '.#tests'` succeeds; `ctest` inside the build reports **100% tests passed, 0 tests failed, out of 265**. Then the three binaries CI runs, exactly as CI runs them:

| CI step | result | exit |
|---|---|---|
| `./result/bin/sdk_tests` | 10 tests from 2 suites, **10 passed** | 0 |
| `./result/bin/generator_tests` | 127 tests from 15 suites, **127 passed** | 0 |
| `FIXTURES_DIR=./result/fixtures ./result/bin/experimental_tests` | 128 tests from 7 suites, **128 passed** | 0 |

265 total, zero failures.

## About the CI installer bump

`@v27` pins Nix **2.22.1**; `@v31` pins **2.35.1** (verified from each tag's `install-nix.sh`). `v31` still accepts the `extra_nix_config` input this workflow passes, so the step is otherwise unchanged. `logos-standalone-app` already runs `@v31` for the same reason.

To be straightforward about it: **this bump is not load-bearing for this PR** — as the table above shows, everything here evaluates and locks fine on 2.22.1, and both versions produce the same derivation. It is included because 2.22.1 is old enough to mis-evaluate flake input overrides that the rest of this chain relies on, and keeping the fleet on one modern Nix removes a class of "green locally, red on CI" surprises. It is easy to drop from this PR if reviewers would rather land it separately.

`doctests.yml` already uses `DeterminateSystems/nix-installer-action`, which tracks latest — left alone.

## Not covered

Per-repo pinning does not fix `logos-capability-module`, which ships prebuilt inside `logos-standalone-app` and reaches an older protocol through its own `logos-module-builder` input. That needs its own chain and is out of scope here.

Please do not merge before the rest of the chain is reviewed together.
