### PR TITLE
fix(generator): defer generated event subscriptions instead of acquiring a replica

### DIFF
--- a/cpp-generator/experimental/lidl_gen_client.cpp
+++ b/cpp-generator/experimental/lidl_gen_client.cpp
@@ -324,7 +324,6 @@ QString lidlMakeHeader(const ModuleDecl& module, BindMode bindMode)
     }
 
     s << "\nprivate:\n";
-    s << "    LogosObject* ensureReplica();\n";
     s << "    template<typename... Args>\n";
     s << "    static QVariantList packVariantList(Args&&... args) {\n";
     s << "        QVariantList list;\n";
@@ -336,7 +335,6 @@ QString lidlMakeHeader(const ModuleDecl& module, BindMode bindMode)
     s << "    LogosAPI* m_api;\n";
     s << "    LogosAPIClient* m_client;\n";
     s << "    QString m_moduleName;\n";
-    s << "    LogosObject* m_eventReplica = nullptr;\n";
     s << "};\n";
 
     return h;
@@ -367,24 +365,13 @@ QString lidlMakeSource(const ModuleDecl& module, BindMode bindMode)
         s << className << "::" << className << "(LogosAPI* api) : m_api(api), m_client(api->getClient(\""
           << module.name << "\")), m_moduleName(QStringLiteral(\"" << module.name << "\")) {}\n\n";
 
-    s << "LogosObject* " << className << "::ensureReplica() {\n";
-    s << "    if (!m_eventReplica) {\n";
-    s << "        LogosObject* replica = m_client->requestObject(m_moduleName);\n";
-    s << "        if (!replica) {\n";
-    s << "            qWarning() << \"" << className << ": failed to acquire remote object for events on\" << m_moduleName;\n";
-    s << "            return nullptr;\n";
-    s << "        }\n";
-    s << "        m_eventReplica = replica;\n";
-    s << "    }\n";
-    s << "    return m_eventReplica;\n";
-    s << "}\n\n";
-
     s << "bool " << className << "::on(const QString& eventName, RawEventCallback callback) {\n";
     s << "    if (!callback) { qWarning() << \"" << className << ": ignoring empty event callback for\" << eventName; return false; }\n";
-    s << "    LogosObject* origin = ensureReplica();\n";
-    s << "    if (!origin) return false;\n";
-    s << "    m_client->onEvent(origin, eventName, callback);\n";
-    s << "    return true;\n";
+    // Deferred: the module is usually NOT reachable at the moment a consumer
+    // subscribes (init(), onContextReady()), and acquiring a replica there used
+    // to block and then fail permanently. onEventWhenAvailable arms it when the
+    // module appears. The return is ACCEPTED, not live.
+    s << "    return m_client->onEventWhenAvailable(m_moduleName, eventName, callback) != 0;\n";
     s << "}\n\n";
 
     s << "bool " << className << "::on(const QString& eventName, EventCallback callback) {\n";

--- a/cpp-generator/legacy/generator_lib.cpp
+++ b/cpp-generator/legacy/generator_lib.cpp
@@ -715,10 +715,6 @@ QString makeHeader(const QString& moduleName, const QString& className, const QJ
           << ", Timeout timeout = Timeout());\n";
     }
     s << "\nprivate:\n";
-    // ensureReplica() is needed whenever the wrapper subscribes to events,
-    // which on the Qt surface is always: the generic `on(...)` channel is
-    // exposed even when the contract declares no typed events.
-    s << "    LogosObject* ensureReplica();\n";
     s << "    template<typename... Args>\n";
     s << "    static QVariantList packVariantList(Args&&... args) {\n";
     s << "        QVariantList list;\n";
@@ -730,7 +726,6 @@ QString makeHeader(const QString& moduleName, const QString& className, const QJ
     s << "    LogosAPI* m_api;\n";
     s << "    LogosAPIClient* m_client;\n";
     s << "    QString m_moduleName;\n";
-    s << "    LogosObject* m_eventReplica = nullptr;\n";
     s << "};\n";
     return h;
 }
@@ -832,28 +827,28 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
         s << className << "::" << className << "(LogosAPI* api) : m_api(api), m_client(api->getClient(\"" << moduleName << "\")), m_moduleName(QStringLiteral(\"" << moduleName << "\")) {}\n\n";
     }
 
-    s << "LogosObject* " << className << "::ensureReplica() {\n";
-    s << "    if (!m_eventReplica) {\n";
-    s << "        LogosObject* replica = m_client->requestObject(m_moduleName);\n";
-    s << "        if (!replica) {\n";
-    s << "            qWarning() << \"" << className << ": failed to acquire remote object for events on\" << m_moduleName;\n";
-    s << "            return nullptr;\n";
-    s << "        }\n";
-    s << "        m_eventReplica = replica;\n";
-    s << "    }\n";
-    s << "    return m_eventReplica;\n";
-    s << "}\n\n";
+    // ensureReplica() is gone: every subscription now goes through
+    // LogosAPIClient::onEventWhenAvailable, which owns the acquire. Keeping a
+    // per-wrapper replica would re-introduce both halves of what it caused —
+    // a blocking requestObject on the subscriber's thread, and a permanent
+    // failure when the module simply had not started yet.
     s << "bool " << className << "::on(const QString& eventName, RawEventCallback callback) {\n";
     s << "    if (!callback) {\n";
     s << "        qWarning() << \"" << className << ": ignoring empty event callback for\" << eventName;\n";
     s << "        return false;\n";
     s << "    }\n";
-    s << "    LogosObject* origin = ensureReplica();\n";
-    s << "    if (!origin) {\n";
-    s << "        return false;\n";
-    s << "    }\n";
-    s << "    m_client->onEvent(origin, eventName, callback);\n";
-    s << "    return true;\n";
+    s << "    // Deferred on purpose. This used to acquire a replica synchronously\n";
+    s << "    // and return false forever if the module was not reachable -- and the\n";
+    s << "    // moment a consumer subscribes (init(), onContextReady(), a view's\n";
+    s << "    // constructor) is exactly the moment it is not, because the\n";
+    s << "    // dependency's host has been spawned but has not called listen() yet.\n";
+    s << "    // onEventWhenAvailable holds the subscription and arms it when the\n";
+    s << "    // module appears, including one installed mid-session, and never\n";
+    s << "    // blocks the calling thread.\n";
+    s << "    //\n";
+    s << "    // The return is therefore ACCEPTED, not live: false only for errors no\n";
+    s << "    // retry can fix (a null callback, an empty module or event name).\n";
+    s << "    return m_client->onEventWhenAvailable(m_moduleName, eventName, callback) != 0;\n";
     s << "}\n\n";
     s << "bool " << className << "::on(const QString& eventName, EventCallback callback) {\n";
     s << "    if (!callback) {\n";
@@ -868,8 +863,10 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
     // Typed event adapters — one per declared event. The callback type
     // uses the apiStyle's type surface; the body unmarshals from the
     // wire's QVariantList into typed args and invokes the user's
-    // callback. Subscription uses the same `m_client->onEvent` channel
-    // the generic `on(...)` uses.
+    // callback. Subscription uses the same deferred
+    // `m_client->onEventWhenAvailable` channel the generic `on(...)` uses —
+    // `m_client->onEvent` is no longer emitted anywhere, because it requires a
+    // handle the subscriber had to acquire (and block for) itself.
     for (const QJsonValue& ev : events) {
         const QJsonObject eo = ev.toObject();
         const QString evName = eo.value("name").toString();
@@ -903,9 +900,8 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
           << "<< QStringLiteral(\"" << evName << "\");\n";
         s << "        return false;\n";
         s << "    }\n";
-        s << "    LogosObject* origin = ensureReplica();\n";
-        s << "    if (!origin) return false;\n";
-        s << "    m_client->onEvent(origin, QStringLiteral(\"" << evName << "\"), "
+        s << "    return m_client->onEventWhenAvailable(m_moduleName, QStringLiteral(\""
+          << evName << "\"), "
           << "[callback](const QString&, const QVariantList& _args) {\n";
         s << "        if (_args.size() < " << evParams.size() << ") return;\n";
         s << "        callback(";
@@ -918,8 +914,7 @@ QString makeSource(const QString& moduleName, const QString& className, const QS
             if (i + 1 < evParams.size()) s << ", ";
         }
         s << ");\n";
-        s << "    });\n";
-        s << "    return true;\n";
+        s << "    }) != 0;\n";
         s << "}\n\n";
     }
 

--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786030193,
-        "narHash": "sha256-Z5rxmZBMJsNsUSb37ljbDMKrtrds9Enw5oPJcf8wbVU=",
+        "lastModified": 1786381943,
+        "narHash": "sha256-/EsIMBCNs3BvssVP/lImCFjEar++cAtusMT7KSoe4VU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "0f26ffdeef18fb9582dc0a95e2bee482464da40d",
+        "rev": "0183e8c26aa3e98ed3603258f2f640385bf61954",
         "type": "github"
       },
       "original": {

--- a/tests/experimental/test_lidl_gen_client.cpp
+++ b/tests/experimental/test_lidl_gen_client.cpp
@@ -156,7 +156,9 @@ TEST(LidlGenClient, SourceHasEventBoilerplate)
     auto m = makeTestModule();
     QString s = lidlMakeSource(m);
     EXPECT_TRUE(s.contains("WalletModule::on(const QString& eventName"));
-    EXPECT_TRUE(s.contains("ensureReplica()"));
+    // Deferred, not a synchronous acquire -- see MakeSourceTest.
+    EXPECT_TRUE(s.contains("onEventWhenAvailable(m_moduleName, eventName, callback)"));
+    EXPECT_FALSE(s.contains("ensureReplica"));
 }
 
 TEST(LidlGenClient, SourceHasReturnConversion)

--- a/tests/generator/test_make_header.cpp
+++ b/tests/generator/test_make_header.cpp
@@ -118,7 +118,11 @@ TEST(MakeHeaderTest, ContainsPrivateMembers)
     EXPECT_TRUE(h.contains("m_api"));
     EXPECT_TRUE(h.contains("m_client"));
     EXPECT_TRUE(h.contains("m_moduleName"));
-    EXPECT_TRUE(h.contains("ensureReplica"));
+    // ensureReplica()/m_eventReplica are gone: the deferred subscription
+    // channel owns the acquire, and a per-wrapper replica would bring back both
+    // the blocking acquire and the permanent failure it caused.
+    EXPECT_FALSE(h.contains("ensureReplica"));
+    EXPECT_FALSE(h.contains("m_eventReplica"));
 }
 
 TEST(MakeHeaderTest, ConstRefForStringParams)

--- a/tests/generator/test_make_source.cpp
+++ b/tests/generator/test_make_source.cpp
@@ -33,10 +33,18 @@ TEST(MakeSourceTest, ConstructorInitializesClient)
     EXPECT_TRUE(src.contains("api->getClient(\"my_mod\")"));
 }
 
-TEST(MakeSourceTest, EnsureReplicaMethod)
+// Subscriptions must be DEFERRED, not acquired synchronously. The generated
+// wrapper used to call requestObject() and return false forever when the module
+// was not reachable -- which is the normal state at the moment a consumer
+// subscribes, so "calls work, events never arrive" was the result. Pinning the
+// emitted call site because a regression here is silent: the wrapper still
+// compiles, still returns a bool, and simply never delivers.
+TEST(MakeSourceTest, SubscribesViaDeferredChannel)
 {
     QString src = makeSource("mod", "Mod", "mod.h", QJsonArray());
-    EXPECT_TRUE(src.contains("LogosObject* Mod::ensureReplica()"));
+    EXPECT_TRUE(src.contains("m_client->onEventWhenAvailable(m_moduleName, eventName, callback)"));
+    EXPECT_FALSE(src.contains("ensureReplica"));
+    EXPECT_FALSE(src.contains("requestObject"));
 }
 
 TEST(MakeSourceTest, ZeroParams)


### PR DESCRIPTION
> [!NOTE]
> **No longer blocked.** `88f6330` bumps the pin to `logos-protocol 0183e8c` in this same PR, so the emitted code compiles. logos-co/logos-cpp-sdk#135 also merged, so CI now compiles *and runs* the Qt emission this changes — see the corrected note below.

## The defect

Both C++ generators emitted, at all three subscription sites (generic `on(QString, RawEventCallback)`, its `EventCallback` overload, and every typed `on<Event>`):

```cpp
LogosObject* origin = ensureReplica();          // blocking requestObject, 20 s default
if (!origin) return false;                       // PERMANENT — never retried
m_client->onEvent(origin, eventName, callback);
```

That asks *"is the module reachable right now"* at the one moment the answer is no. Every C++ consumer subscribes from `init()`, `onContextReady()` or a backend constructor — all of which run while the dependency's host has been spawned but has not called `listen()` yet. Real users of this path: `wallet-ui/src/wallet_ui_backend.cpp:17`, `logos-tutorial/outputs/logos-calc-ui-cpp/src/calc_ui_cpp_backend.cpp:72`.

The guard inside `requestObject` was **dead code for years** (`isConnected()` returned a latch that was always true), so it fell through to a blocking wait that usually succeeded, slowly. logos-co/logos-protocol#47 makes `isConnected()` truthful — which turns this same code into an instant, permanent, silent failure. **Without this PR, #47 makes Qt C++ event subscriptions worse, not better.**

All three sites now route through `onEventWhenAvailable`, and `ensureReplica()`/`m_eventReplica` are deleted from both generators.

## Verified at three levels

The first two prove less than they look, which is worth stating because it is how this survived:

| level | result |
|---|---|
| **emits** | 265/265 cpp-sdk tests. Goldens now pin the emitted *call site* and `EXPECT_FALSE` the removed symbols — but they are string comparisons and would pass on code that does not compile |
| **compiles** | Both generators' output compiled against the local protocol branch, EXIT=0, including a 15-event contract with a 3-parameter event |
| **defers** | Real A/B on a live `qt_remote` transport with real generated code: **7/7 green migrated, 3/3 red in 0-8 ms on the pristine generator**, published-first controls green in both |

## Merge order — this is the blocker

This repo pins `logos-protocol 0f26ffd`, which has **zero** occurrences of `onEventWhenAvailable`. Compiling the emitted wrapper against that exact tree: **EXIT=1, 16 errors**, every one `no member named 'onEventWhenAvailable' in 'LogosAPIClient'`.

1. ~~Merge logos-co/logos-protocol#47.~~ **Merged**, along with #53 and #55.
2. ~~Bump this repo's `flake.lock` protocol pin in the same PR as this diff.~~ **Done in `88f6330`** — pinned to `0183e8c`, deliberately *not* the first commit introducing `onEventWhenAvailable`: #47's tip also carries the `tryAcquireNow` use-after-free fix, and generated Qt consumers subscribe in exactly the shape that triggers it (one `on<Event>` per declared event, from `init()`). A lower pin would make this crash rather than merely fail to compile.
3. Re-pin downstream.

## Two things reviewers should know

**~~cpp-sdk CI cannot catch a regression here.~~ It can now — hole closed.** This was true when written: all 7 module definitions across all 5 specs in `doctests/` were `"interface": "universal"`, resolving to `ApiStyle::Lp` and early-returning before the code this diff touches, so no job compiled or executed a single line of the changed emission.

#135 added `cpp-sdk-qt-api-events.test.yaml`, which builds a Qt provider-style consumer against the SDK commit under test and runs it in a `logoscore` daemon. It is green on both platforms, and its assertions are exactly the ones that matter here: the subscription is **accepted** at `onInit()` while the dependency is unreachable, the event **arrives decoded into a `QString`**, and it arrives **exactly once**. Because nix realises `headers-qt` only when something depends on it, that spec is also the first thing in this repo ever to run that generator invocation at all.

So this PR's emission change is now covered by a job that compiles and executes it, rather than by golden string comparisons that would pass on code which does not build.

**~~A measured regression this cannot fix.~~ Fixed upstream — no longer outstanding.** A consumer that makes a successful sync call and *then* subscribes — `wallet_ui_backend.cpp:13` calls `get_chains()`, then subscribes at `:17` — used to drop events for ~50 ms after this migration (1/1 delivered pre-migration, 0/1 post, 3/3 runs). This was correctly identified as a protocol-layer decision rather than a generator one, and logos-co/logos-protocol#47 has since made it: [`e9f82ac`](https://github.com/logos-co/logos-protocol/commit/e9f82ac688d357f07e57000cb224a0719178c7a6) adds `LogosTransportAsyncAcquire::tryAcquireNow()`, which hands back a handle **only when that costs nothing** — for `qt_remote`, a replica that is already `Valid`, which is exactly the state a prior successful call leaves behind, since QtRO shares one replica implementation per object name per node. `PendingSubscriptions::beginAcquire` tries it first and arms synchronously when it answers, so the subscription is live before `on()` returns, as it was before deferral.

It sidesteps the ownership problem rather than solving it: nothing reads `m_objectCache`, so the call path can still `release()` its own handle without touching a subscription. The default implementation returns `nullptr`, so a transport that cannot answer cheaply simply does not, and the deferred path still owns every case where the module is not already there. Pinned by the `SubscribeRightAfterACall_DeliversImmediately` matrix case, which fires once with no pumping in between — re-firing would hide the exact gap under test. `plain` asserts only that it still arms and delivers: registration there is a wire frame to the host, so instant delivery was never on offer and never was before this change either.

**Nothing to do in this PR.** It does mean the protocol pin in step 2 of the merge order must be at least `e9f82ac`, not merely the first commit of #47 that introduces `onEventWhenAvailable`.

*Unrelated:* this repo's test derivation fails on some machines because `gtest_discover_tests` runs the binary with a 5 s `TEST_DISCOVERY_TIMEOUT`; the pristine tree fails identically. The 265/265 above came from a copy with that raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

