### PR TITLE
feat(windows): add an x86_64-windows cross target

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785470541,
-        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -27,14 +27,15 @@
     },
     "logos-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-windows": "nixpkgs-windows"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -55,11 +56,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786381943,
-        "narHash": "sha256-/EsIMBCNs3BvssVP/lImCFjEar++cAtusMT7KSoe4VU=",
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "0183e8c26aa3e98ed3603258f2f640385bf61954",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
         "type": "github"
       },
       "original": {
@@ -81,6 +82,22 @@
         "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -17,12 +17,16 @@
   outputs = { self, nixpkgs, logos-nix, logos-protocol, logos-lidl }:
     let
       systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
+      # Adds the "x86_64-windows" pseudo-system; a cross derivation's `system`
+      # is its BUILD platform, so it evaluates anywhere and realises on Linux.
+      forAllTargets = logos-nix.lib.forAllTargets;
+
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f {
         pkgs = import nixpkgs { inherit system; };
       });
     in
     {
-      packages = forAllSystems ({ pkgs }: 
+      packages = forAllTargets ({ pkgs, ... }: 
         let
           # Common configuration
           common = import ./nix/default.nix { inherit pkgs; };

--- a/nix/bin.nix
+++ b/nix/bin.nix
@@ -3,6 +3,10 @@
 
 pkgs.stdenv.mkDerivation {
   pname = "${common.pname}-generator";
+  # qtbase\'s setup hook errors in qtPreHook unless a wrapper hook ran or
+  # this is set; the wrapper hooks are absent on Windows (they cannot even
+  # evaluate for a mingw host) and would skip a PE anyway.
+  dontWrapQtApps = true;
   version = common.version;
 
   inherit src;

--- a/nix/bin.nix
+++ b/nix/bin.nix
@@ -34,11 +34,25 @@ pkgs.stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
     
-    # Install generator binary
+    # Install generator binary.
+    #
+    # Probe both names and FAIL if neither is there. The unsuffixed-only test
+    # this replaces had no else-branch, so a mingw build (which produces
+    # logos-cpp-generator.exe) copied nothing, succeeded, and shipped an EMPTY
+    # $out/bin -- the failure then surfaced in whichever consumer tried to run
+    # the generator, nowhere near the cause.
     mkdir -p $out/bin
-    if [ -f build-generator/bin/logos-cpp-generator ]; then
-      cp build-generator/bin/logos-cpp-generator $out/bin/
+    _gen=""
+    for _cand in build-generator/bin/logos-cpp-generator build-generator/bin/logos-cpp-generator.exe; do
+      if [ -f "$_cand" ]; then _gen="$_cand"; break; fi
+    done
+    if [ -z "$_gen" ]; then
+      echo "Error: logos-cpp-generator was not produced by the build" >&2
+      echo "Contents of build-generator/bin:" >&2
+      ls -la build-generator/bin 2>&1 >&2 || echo "  (no such directory)" >&2
+      exit 1
     fi
+    cp "$_gen" $out/bin/
 
     # Shared C++/Qt codegen backend helpers for logos-qt-sdk's
     # logos-qt-generator: the Qt type-name mapping (lidl_emit_common), the

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,8 +10,8 @@
     pkgs.cmake 
     pkgs.ninja 
     pkgs.pkg-config
-    pkgs.qt6.wrapQtAppsNoGuiHook
-  ];
+  ]
+  ++ pkgs.lib.optional (!pkgs.stdenv.hostPlatform.isWindows) pkgs.qt6.wrapQtAppsNoGuiHook;
   
   # Common runtime dependencies
   buildInputs = [
@@ -41,12 +41,16 @@
   ];
   
   # Common CMake flags
-  cmakeFlags = [ "-GNinja" ];
+  cmakeFlags = [ "-GNinja" ]
+    # Qt's host TOOLS (repc, moc, qmltyperegistrar) live in separate packages
+    # that must RUN on the build machine; logos-nix's Windows overlay exposes
+    # the flags pointing Qt at them. Absent -- so empty -- on native builds.
+    ++ (pkgs.logosQtCrossCmakeFlags or [ ]);
   
   # Metadata
   meta = with pkgs.lib; {
     description = "Logos C++ SDK Library and Code Generator";
-    platforms = platforms.unix;
+    platforms = platforms.unix ++ platforms.windows;
   };
 }
 

--- a/nix/include.nix
+++ b/nix/include.nix
@@ -6,6 +6,10 @@
 
 pkgs.stdenv.mkDerivation {
   pname = "${common.pname}-headers";
+  # qtbase\'s setup hook errors in qtPreHook unless a wrapper hook ran or
+  # this is set; the wrapper hooks are absent on Windows (they cannot even
+  # evaluate for a mingw host) and would skip a PE anyway.
+  dontWrapQtApps = true;
   version = common.version;
 
   inherit src;

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -5,6 +5,10 @@
 
 pkgs.stdenv.mkDerivation {
   pname = "${common.pname}-lib";
+  # qtbase\'s setup hook errors in qtPreHook unless a wrapper hook ran or
+  # this is set; the wrapper hooks are absent on Windows (they cannot even
+  # evaluate for a mingw host) and would skip a PE anyway.
+  dontWrapQtApps = true;
   version = common.version;
 
   inherit src;


### PR DESCRIPTION
Windows cross target for the C++ SDK and its code generator. **L3 of the Windows chain**, re-pinned to the merged `logos-nix`, `logos-protocol` and `logos-lidl`.

The cleanest of the level: master's tree plus the nix files, and one real defect.

## The cross target

`packages` goes through `forAllTargets`, adding the `x86_64-windows` pseudo-system alongside the native ones, and `meta.platforms` is widened. `cmakeFlags` pick up `pkgs.logosQtCrossCmakeFlags`, which is empty natively.

`qt6.wrapQtAppsNoGuiHook` is dropped for Windows and `dontWrapQtApps` set on each derivation. **Both halves are needed**: the hook does not evaluate for a mingw host, it would skip a PE anyway (`wrap-qt-apps-hook.sh` handles only ELF and Mach-O), and qtbase's setup hook hard-errors in `qtPreHook` without the flag.

## The defect: an empty $out/bin that exited 0

The install test named only the unsuffixed `logos-cpp-generator` and had no else-branch, so a mingw build — which produces `logos-cpp-generator.exe` — copied nothing, **succeeded**, and shipped an empty `$out/bin`. The failure then surfaced in whichever consumer tried to run the generator, nowhere near the cause.

It now probes both names and exits 1 with a directory listing if neither is there. Verified: the Windows build installs a real PE, and the native build is unchanged.

This is the shape that recurs across this chain — a glob that matches nothing on Windows, guarded so that matching nothing is indistinguishable from success. Worth reviewing with that in mind rather than as a one-off.
