### PR TITLE
fix(host-core): read the stats keys process-stats actually emits

### DIFF
--- a/cpp/logos_host_core.h
+++ b/cpp/logos_host_core.h
@@ -104,7 +104,12 @@ namespace host {
 struct ModuleStats {
     std::string name;
     double      cpuPercent = 0.0;
-    long long   memoryBytes = 0;
+    double      cpuTimeSeconds = 0.0;
+    // MEGABYTES, not bytes — that is what the producer emits
+    // (process-stats/src/process_stats.h: `double memoryMB`). This member was
+    // `long long memoryBytes` and read a key that does not exist, so it was
+    // both the wrong unit and always zero.
+    double      memoryMb = 0.0;
     // The raw entry, so a host can read fields this struct does not model
     // without waiting for the SDK to grow them.
     nlohmann::json raw;
@@ -298,8 +303,13 @@ public:
             if (!entry.is_object()) continue;
             ModuleStats s;
             s.name = entry.value("name", std::string{});
-            s.cpuPercent = entry.value("cpu", 0.0);
-            s.memoryBytes = entry.value("memory", 0LL);
+            // Key names are process-stats' (src/process_stats.cpp:157-161):
+            // name, cpu_percent, cpu_time_seconds, memory_mb. This read "cpu"
+            // and "memory", which are emitted by nothing, so every host that
+            // adopted this façade would have silently reported 0 for both.
+            s.cpuPercent     = entry.value("cpu_percent", 0.0);
+            s.cpuTimeSeconds = entry.value("cpu_time_seconds", 0.0);
+            s.memoryMb       = entry.value("memory_mb", 0.0);
             s.raw = entry;
             out.push_back(std::move(s));
         }

--- a/tests/sdk/test_logos_host_core.cpp
+++ b/tests/sdk/test_logos_host_core.cpp
@@ -40,7 +40,11 @@ struct CoreStub {
 
     std::vector<std::string> known{"alpha", "beta", "gamma"};
     std::vector<std::string> loaded{"alpha"};
-    std::string statsJson = R"([{"name":"alpha","cpu":12.5,"memory":4096}])";
+    // The REAL contract process-stats emits (src/process_stats.cpp:157-161).
+    // This previously stubbed {"cpu":..,"memory":..}, keys nothing produces, so
+    // it validated the parser's bug instead of the producer's format.
+    std::string statsJson =
+        R"([{"name":"alpha","cpu_percent":12.5,"cpu_time_seconds":3.5,"memory_mb":4096.0}])";
     bool tokenPresent = true;
     int  lastLoadWithDeps = -1;
     int  lastUnloadWithDependents = -1;
@@ -226,7 +230,8 @@ TEST_F(HostCoreTest, StatsAreIndexedOutOfTheSingleBlob)
     ASSERT_TRUE(s.has_value());
     EXPECT_EQ(s->name, "alpha");
     EXPECT_DOUBLE_EQ(s->cpuPercent, 12.5);
-    EXPECT_EQ(s->memoryBytes, 4096);
+    EXPECT_DOUBLE_EQ(s->memoryMb, 4096.0);
+    EXPECT_DOUBLE_EQ(s->cpuTimeSeconds, 3.5);
     EXPECT_EQ(s->raw["name"], "alpha") << "the raw entry stays reachable";
 }
 


### PR DESCRIPTION
`logos_host_core.h`'s stats parser reads `"cpu"` and `"memory"`. The only producer, `process-stats/src/process_stats.cpp:157-161`, emits:

```
name, cpu_percent, cpu_time_seconds, memory_mb
```

So `ModuleStats::cpuPercent` and `::memoryBytes` are **permanently 0 for every module**. `memoryBytes` is doubly wrong: `ProcessStatsData::memoryMB` is a `double` in **megabytes**, so the member misnamed the unit *and* modelled the wrong type.

Fixed: reads the real keys, `memoryBytes` → `memoryMb` (double), and `cpu_time_seconds` is now modelled rather than reachable only through `raw`.

## Why it survived

`tests/sdk/test_logos_host_core.cpp` stubs `logos_core_get_module_stats()` itself — and stubbed it as `{"cpu":12.5,"memory":4096}`, keys nothing produces. The test asserted the parser's bug against a fixture built to match it. Green, and it would have stayed green forever. The stub is now derived from `process_stats.cpp`.

## Why it matters now

The `::host` façade has **no production consumers**. The first host to adopt it would have silently reported 0.0% CPU and 0.0 MB for every module.

Worth noting what that implies: `logos-basecamp`'s hand-rolled parser — the thing this façade is meant to replace — reads `cpu_percent` with a `cpu` fallback and `memory_mb` with `memory`/`memory_MB` fallbacks (`CoreModuleManager.cpp:252-259`). It was already more correct than the abstraction, and version-tolerant besides. Migrating basecamp today would have been a regression.

## Ordering

logos-qt-sdk's veneer mirrors these fields into a `QVariantMap` and needs the matching change. That is a separate PR and **must land after this one** — verified: qt-sdk's tests fail to compile against the old struct (`no member named cpuTimeSeconds / memoryMb`) and pass with this branch overridden in.

`checks.tests` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)