### PR TITLE
docs(doctests): drop references to the archived logos-module-client

### DIFF
--- a/doctests/outputs/cpp-sdk-module-composition.md
+++ b/doctests/outputs/cpp-sdk-module-composition.md
@@ -508,7 +508,6 @@ daemon can scan.
 nix build 'github:logos-co/logos-logoscore-cli' \
   --override-input logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
   --override-input logos-liblogos/logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
-  --override-input logos-module-client/logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
   --override-input logos-capability-module/logos-module-builder/logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
   --out-link ./logos
 ```

--- a/doctests/outputs/cpp-sdk-module-runtime.md
+++ b/doctests/outputs/cpp-sdk-module-runtime.md
@@ -10,7 +10,7 @@ the headless `logoscore` runtime:
 
 1. Build the `logoscore` CLI, **overriding `logos-cpp-sdk` with the commit
    under test** — and overriding it in the same way for every consumer in
-   `logoscore`'s closure (`logos-liblogos`, `logos-module-client`, and the
+   `logoscore`'s closure (`logos-liblogos` and the
    `capability_module`'s `logos-module-builder`). Because the published flakes
    pin the SDK independently (there is no single `follows` unifying them), all
    of these must point at the same commit so the whole runtime is built and
@@ -61,8 +61,8 @@ Build the `logoscore` CLI from its published flake, but **override
 every consumer that pins the SDK in `logoscore`'s closure. The result is
 symlinked to `./logos/`.
 
-> Unlike a leaf input, the SDK is pinned independently by `logos-liblogos`,
-> `logos-module-client`, and the `capability_module`'s `logos-module-builder`
+> Unlike a leaf input, the SDK is pinned independently by `logos-liblogos`
+> and the `capability_module`'s `logos-module-builder`
 > — there is no single `follows` tying them together in the published
 > flakes. So we override it at each of those paths (e.g.
 > `--override-input logos-liblogos/logos-cpp-sdk …`) to keep the whole
@@ -77,7 +77,6 @@ symlinked to `./logos/`.
 nix build 'github:logos-co/logos-logoscore-cli' \
   --override-input logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
   --override-input logos-liblogos/logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
-  --override-input logos-module-client/logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
   --override-input logos-capability-module/logos-module-builder/logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
   --out-link ./logos
 ```

--- a/doctests/outputs/cpp-sdk-worker-thread-http.md
+++ b/doctests/outputs/cpp-sdk-worker-thread-http.md
@@ -450,7 +450,6 @@ with the capability module, and install both modules.
 nix build 'github:logos-co/logos-logoscore-cli' \
   --override-input logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
   --override-input logos-liblogos/logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
-  --override-input logos-module-client/logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
   --override-input logos-capability-module/logos-module-builder/logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
   --out-link ./logos
 ```


### PR DESCRIPTION
`logos-module-client` is being archived. It has **no consumers**: nothing declares it as a flake input, nothing lists it as a dependency in the workspace `dep-graph.nix`, and no source or header outside its own tree references it.

These three generated outputs were the last thing implying otherwise.

## What was stale

**Two prose mentions** (`cpp-sdk-module-runtime.md`) describing it as one of the repos that pins the SDK independently.

**Three command lines**, one per output — and these are the ones worth removing rather than leaving:

```
--override-input logos-module-client/logos-cpp-sdk 'github:logos-co/logos-cpp-sdk' \
```

That sits inside a command the reader is invited to run. Overriding an input that does not exist is only a nix **warning**, not an error, so the command appears to work while doing nothing at that path. The failure mode is silence, which is why it went unnoticed.

## Why the generator did not catch it

The live specs in `doctests/*.yaml` are **already clean** — they emit no such override. Only `outputs/*.md` drifted, which is expected: those files are hand-pinned and CI never diffs them against the generator, so nothing was going to flag it.

Docs only — no spec, code or lock changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)