### PR TITLE
test(abi): assert the generated cdylib defines every declared module-impl export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,12 @@ jobs:
         run: ./result/bin/experimental_tests
         env:
           FIXTURES_DIR: ./result/fixtures
+
+      # The module-impl C ABI: does the cdylib backend still DEFINE every
+      # export logos-protocol DECLARES? Not implied by `.#tests` above — the
+      # gtest suite never leaves the generator's internals — and not catchable
+      # downstream either: a module missing an export links clean and dies at
+      # dlopen(). Runs here, on Linux, where that would actually happen.
+      # --no-link so the `result` symlink the steps above use is left alone.
+      - name: Check the module-impl C ABI is fully defined
+        run: nix build --no-link '.#checks.x86_64-linux.module-impl-abi'

--- a/flake.lock
+++ b/flake.lock
@@ -56,17 +56,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787318305,
+        "lastModified": 1787324808,
         "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "986813cc661682878c3ecabff2078a6d36cd5c1d",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "986813cc661682878c3ecabff2078a6d36cd5c1d",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -56,16 +56,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1787267788,
-        "narHash": "sha256-naE4VE+F0zLsCfa/9hL7+RRRW49Pg1HisH3kOymHaKU=",
+        "lastModified": 1787318305,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "0d2a3c06bfb6c5c9701da84f77afe4aab86403c6",
+        "rev": "986813cc661682878c3ecabff2078a6d36cd5c1d",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-protocol",
+        "rev": "986813cc661682878c3ecabff2078a6d36cd5c1d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,13 +7,15 @@
   # logos-nix so both repos resolve the identical nixpkgs/Qt pin — the QRO
   # wire is Qt-version-sensitive.
   #
-  # Master-tracking. This was rev-pinned to feat/per-client-token-store while
-  # logos_host_services.h's trust-root surface (lp_token_keys,
-  # lp_inform_module_token_to, lp_grant_host_services) lived only on that
-  # branch, with protocol master still at LOGOS_PROTOCOL_VERSION_MINOR 2 —
-  # the `tests` check could not compile against it. That branch has merged
-  # (logos-protocol#59): master is 0.4.0 and carries all three.
-  inputs.logos-protocol.url = "github:logos-co/logos-protocol";
+  # TEMPORARILY REV-PINNED to logos-protocol#66 (feat/module-impl-abi-manifest).
+  # That branch publishes packages.<system>.module-impl-abi: the module-impl C
+  # ABI export list, the protocol version the list belongs to, and the diff
+  # helper. nix/tests-module-impl-abi.nix reads all three, and master does not
+  # carry them yet, so unpinned this repo cannot even evaluate that check.
+  # TODO: drop the rev, back to plain "github:logos-co/logos-protocol", once
+  # logos-protocol#66 merges. Nothing else here depends on the rev — the
+  # earlier pin to feat/per-client-token-store was dropped when #59 merged.
+  inputs.logos-protocol.url = "github:logos-co/logos-protocol/986813cc661682878c3ecabff2078a6d36cd5c1d";
   inputs.logos-protocol.inputs.logos-nix.follows = "logos-nix";
   # The canonical, language-neutral LIDL frontend (lexer/parser/AST/serializer/
   # validator) the code generator links. Follows our logos-nix so it resolves
@@ -88,6 +90,14 @@
           # never executes it, so a retired CLI flag can only be asserted here.
           generator-cli = import ./nix/tests-generator-cli.nix {
             inherit pkgs common generator;
+          };
+          # Diffs what the cdylib backend DEFINES against the module-impl C
+          # ABI logos-protocol DECLARES. Nothing else here can catch that gap:
+          # a module with a missing export links clean and only dies at
+          # dlopen(), on Linux. See nix/tests-module-impl-abi.nix.
+          module-impl-abi = import ./nix/tests-module-impl-abi.nix {
+            inherit pkgs common src generator;
+            module-impl-abi = logos-protocol.packages.${pkgs.system}.module-impl-abi;
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -7,15 +7,16 @@
   # logos-nix so both repos resolve the identical nixpkgs/Qt pin — the QRO
   # wire is Qt-version-sensitive.
   #
-  # TEMPORARILY REV-PINNED to logos-protocol#66 (feat/module-impl-abi-manifest).
-  # That branch publishes packages.<system>.module-impl-abi: the module-impl C
-  # ABI export list, the protocol version the list belongs to, and the diff
-  # helper. nix/tests-module-impl-abi.nix reads all three, and master does not
-  # carry them yet, so unpinned this repo cannot even evaluate that check.
-  # TODO: drop the rev, back to plain "github:logos-co/logos-protocol", once
-  # logos-protocol#66 merges. Nothing else here depends on the rev — the
-  # earlier pin to feat/per-client-token-store was dropped when #59 merged.
-  inputs.logos-protocol.url = "github:logos-co/logos-protocol/986813cc661682878c3ecabff2078a6d36cd5c1d";
+  # Master-tracking. This was rev-pinned to feat/per-client-token-store while
+  # logos_host_services.h's trust-root surface (lp_token_keys,
+  # lp_inform_module_token_to, lp_grant_host_services) lived only on that
+  # branch, with protocol master still at LOGOS_PROTOCOL_VERSION_MINOR 2 —
+  # the `tests` check could not compile against it. That branch has merged
+  # (logos-protocol#59): master is 0.4.0 and carries all three.
+  #
+  # checks.module-impl-abi additionally consumes
+  # packages.<system>.module-impl-abi from here (logos-protocol#66).
+  inputs.logos-protocol.url = "github:logos-co/logos-protocol";
   inputs.logos-protocol.inputs.logos-nix.follows = "logos-nix";
   # The canonical, language-neutral LIDL frontend (lexer/parser/AST/serializer/
   # validator) the code generator links. Follows our logos-nix so it resolves

--- a/nix/tests-module-impl-abi.nix
+++ b/nix/tests-module-impl-abi.nix
@@ -1,0 +1,218 @@
+# Asserts that the cdylib backend DEFINES every module-impl C ABI export
+# logos-protocol DECLARES.
+#
+# Why this is not implied by anything else we build. logos-protocol only
+# declares the ABI (the LOGOS_MODULE_IMPL_EXPORT functions in
+# cpp/logos_module_impl.h); this repo's generator writes the definitions. Those
+# are independent facts and the gap has shipped twice — grant_host_services at
+# protocol 0.3, the teardown pair at 0.5 — each time with the header and the
+# generator in perfect agreement about the protocol VERSION and in silent
+# disagreement about the symbol list.
+#
+# It hides because nothing on the build path looks at it. An undefined symbol in
+# an ELF shared object is legal at link time, so a module links clean; nixpkgs
+# hardens with -Wl,-z,now, which makes resolution eager and therefore fatal at
+# dlopen(). macOS links plugins with -undefined dynamic_lookup and never binds
+# at all, so a green Darwin build proves nothing — and this check is the only
+# thing in the repo that would notice on a Mac. The runtime then reports the
+# module as LOADED and what an operator sees is other modules timing out.
+#
+# The declared list and the protocol version both come from ONE logos-protocol
+# input, so there is no version arithmetic here and nothing hardcoded: "what
+# this protocol requires" is just "what the header at this pin declares".
+{ pkgs, common, src, generator, module-impl-abi }:
+
+pkgs.runCommand "${common.pname}-module-impl-abi-tests"
+  {
+    nativeBuildInputs = [ generator module-impl-abi pkgs.unifdef ];
+    meta = common.meta;
+  }
+  ''
+    # pipefail stated here rather than inherited: stdenv sets it today, the one
+    # pipeline below that may legitimately match nothing turns it back off
+    # around itself, and neither of those should depend on the ambient shell.
+    set -eu -o pipefail
+    fail() { echo "FAIL: $*" >&2; exit 1; }
+
+    fixtures=${src}/tests/experimental/fixtures
+    declared=${module-impl-abi}/exports.txt
+    hint='cpp-generator/experimental/lidl_gen_cdylib.cpp, in lidlMakeModuleImplExports()'
+
+    # The MINOR the generated `#if LOGOS_PROTOCOL_VERSION_MINOR >= N` guards are
+    # resolved at. It comes from the SAME logos-protocol output as the export
+    # list, so the two can never be read from different revisions.
+    #
+    # Parsed strictly: an unparseable version would hand unifdef an empty -D
+    # value, every guard would evaluate false, and the check would then measure
+    # a protocol nobody pinned.
+    minor=$(cut -d. -f2 < ${module-impl-abi}/version)
+    case "x$minor" in
+      x|x*[!0-9]*) fail "protocol version '$(cat ${module-impl-abi}/version)' has no numeric MINOR" ;;
+    esac
+    echo "logos-protocol $(cat ${module-impl-abi}/version) declares $(wc -l < "$declared" | tr -d ' ') module-impl exports;" \
+         "resolving generated code at LOGOS_PROTOCOL_VERSION_MINOR=$minor"
+
+    # ── Resolve, then extract ────────────────────────────────────────────────
+    #
+    # The emitter writes the version guards as TEXT — they are resolved when the
+    # MODULE compiles, not when the generator runs — so a plain grep of the
+    # generated .cpp finds all ten exports at every protocol version and would
+    # pass vacuously. unifdef is what turns the text into the symbol set a
+    # module built against THIS protocol would actually export.
+    #
+    # unifdef's own failure mode is the second vacuity path: given an expression
+    # it cannot evaluate it exits 0 and leaves the text alone, which looks
+    # exactly like "nothing was conditional". Hence the residual-conditional
+    # assertion below. (rc 0 = unchanged, 1 = changed, >=2 = error.)
+    # $cfg_label is set by assert_config before each call: A and B both emit a
+    # file called universal_mod_module_impl.cpp, so naming the file alone leaves
+    # the reader unable to tell which configuration failed.
+    cfg_label="(no configuration)"
+    resolved_symbols() {   # <out-dir> <minor> <src.cpp>...
+      outdir="$1"; m="$2"; shift 2
+      rm -rf "$outdir"; mkdir -p "$outdir"
+      for f in "$@"; do
+        set +e
+        unifdef -DLOGOS_PROTOCOL_VERSION_MINOR="$m" "$f" > "$outdir/$(basename "$f")"
+        rc=$?
+        set -e
+        [ "$rc" -le 1 ] || fail "[$cfg_label] unifdef exited $rc on $f"
+        if grep -nE '^[[:space:]]*#[[:space:]]*(if|ifdef|ifndef|else|elif|endif)' \
+             "$outdir/$(basename "$f")" >&2; then
+          fail "[$cfg_label] unifdef left the conditionals above unresolved in $(basename "$f")"
+        fi
+      done
+      # A DEFINITION only: column zero (the emitter writes them at file scope
+      # inside `extern "C"`), a name immediately followed by "(", and no
+      # trailing ";". Deliberately strict rather than generous — `logos_module_
+      # emit_cb g_emitCb` and `#include "logos_module_impl.h"` are both in this
+      # file, and counting a mention as a definition is how this check would go
+      # green over a missing export. If the emitter ever reflows its output past
+      # this pattern the extraction UNDER-reports, which fails the diff loudly;
+      # there is no shape of generated code that makes it over-report.
+      #
+      # pipefail is off for the pipe itself: matching nothing is a legitimate
+      # outcome (the events sidecar defines no export, by design), and stdenv
+      # runs builders with `set -o pipefail`, which turns that grep's exit 1
+      # into a build failure with no diagnostic at all. Emptiness is judged by
+      # the callers below and by logos-module-impl-diff, never by the pipe.
+      set +o pipefail
+      cat "$outdir"/*.cpp < /dev/null \
+        | grep -E '^[^[:space:]/#].*[[:space:]*&]logos_module_[a-z0-9_]+[[:space:]]*\(' \
+        | grep -vE ';[[:space:]]*$' \
+        | grep -oE 'logos_module_[a-z0-9_]+[[:space:]]*\(' \
+        | sed 's/[[:space:]]*($//' \
+        | sort -u > "$outdir.txt"
+      set -o pipefail
+    }
+
+    assert_config() {   # <label> <generated-dir>
+      label="$1"; dir="$2"; cfg_label="$label"
+      # nixpkgs builders run with `shopt -s nullglob`, so a non-matching
+      # "$dir"/*.cpp expands to NOTHING rather than staying literal: `ls` would
+      # then list the cwd and exit 0, and this guard would never fire. Count the
+      # expansion itself instead.
+      set -- "$dir"/*.cpp
+      [ "$#" -gt 0 ] || fail "[$label] the generator emitted no .cpp at all"
+
+      # Every .cpp the generator wrote, because that is what a module compiles.
+      resolved_symbols "$dir/at-$minor" "$minor" "$dir"/*.cpp
+      resolved_symbols "$dir/at-0"      0        "$dir"/*.cpp
+      n=$(wc -l < "$dir/at-$minor.txt" | tr -d ' ')
+      n0=$(wc -l < "$dir/at-0.txt" | tr -d ' ')
+
+      # THE anti-vacuity assertion, and the reason the pipeline is run twice.
+      # Resolving the same sources with every guard forced false must yield a
+      # strictly smaller set. If unifdef silently no-opped, or the extraction
+      # were matching mentions rather than definitions, or the version never
+      # reached unifdef at all, the two runs would agree and this fires. Note
+      # what it does NOT do: name a symbol or a version. It only insists the
+      # conditionals are live, which is what makes the diff below meaningful.
+      if [ "$minor" -ge 3 ]; then
+        [ -z "$(comm -13 "$dir/at-$minor.txt" "$dir/at-0.txt")" ] \
+          || fail "[$label] MINOR=0 defines exports MINOR=$minor does not"
+        [ "$n0" -lt "$n" ] \
+          || fail "[$label] $n0 exports at MINOR=0 and $n at MINOR=$minor: the guards are inert"
+      else
+        # Below 0.3 nothing is gated, so the live assertion is that the two
+        # resolutions are IDENTICAL. Never a skip: a skipped probe is the same
+        # unexamined green this whole file exists to prevent.
+        cmp -s "$dir/at-0.txt" "$dir/at-$minor.txt" \
+          || fail "[$label] protocol 0.$minor gates no export, yet the two resolutions differ"
+      fi
+      echo "  [$label] version probe: $n0 exports at MINOR=0, $n at MINOR=$minor"
+
+      # The events sidecar is a second TU emitted next to the exports one. It
+      # must carry no module-impl symbol of its own: two TUs defining the same
+      # export is a duplicate-symbol link error, and an export that MOVED there
+      # would still be found by the diff above, so only this says where it lives.
+      for ev in "$dir"/*_events_cdylib.cpp; do
+        [ -e "$ev" ] || continue
+        resolved_symbols "$dir/events" "$minor" "$ev"
+        [ ! -s "$dir/events.txt" ] \
+          || { cat "$dir/events.txt" >&2
+               fail "[$label] the events sidecar defines module-impl exports (above)"; }
+        echo "  [$label] the events sidecar defines no module-impl export"
+      done
+
+      # Refuses an empty file on either side, and allows extra symbols on ours:
+      # declared must be a SUBSET of defined, not equal to it.
+      logos-module-impl-diff "$declared" "$dir/at-$minor.txt" "$label" "$hint"
+    }
+
+    mkdir -p work && cd work
+
+    # ── A. Header-first ──────────────────────────────────────────────────────
+    logos-cpp-generator --from-header "$fixtures/universal_impl.h" \
+      --impl-class UniversalImpl --metadata "$fixtures/universal_metadata.json" \
+      --backend cdylib --output-dir ./A >/dev/null \
+      || fail "A: --from-header was refused"
+    assert_config "A: --from-header, header-first" ./A
+
+    # ── B. Contract-first ────────────────────────────────────────────────────
+    # A SEPARATE branch of main.cpp, reached only by --lidl, and the one a
+    # module whose contract is committed as .lidl actually takes. It shares the
+    # emitter with A today; nothing but this check says it still does. Fed the
+    # .lidl A itself wrote, so the two configurations describe one module.
+    logos-cpp-generator --lidl ./A/universal_mod.lidl --backend cdylib \
+      --impl-class UniversalImpl --impl-header universal_impl.h --output-dir ./B >/dev/null \
+      || fail "B: --lidl --backend cdylib was refused (it needs --impl-class/--impl-header)"
+    assert_config "B: --lidl, contract-first" ./B
+
+    # ── C. Zero methods ──────────────────────────────────────────────────────
+    # The exports are a fixed surface, not something accumulated per method. A
+    # module with an empty impl class must still define the whole set — it is
+    # the shape most likely to lose one to an emitter that only writes what it
+    # thinks it needs. (The generator warns about the empty class; expected.)
+    logos-cpp-generator --from-header "$fixtures/empty_class_impl.h" \
+      --impl-class EmptyClassImpl --metadata "$fixtures/empty_metadata.json" \
+      --backend cdylib --output-dir ./C >/dev/null 2>&1 \
+      || fail "C: the zero-method fixture was refused"
+    assert_config "C: zero-method module" ./C
+
+    # ── D. Records + events ──────────────────────────────────────────────────
+    # Records pull in the generated codec and events add the second TU, which
+    # together are what change the emitted file set. The metadata is written
+    # here rather than added to tests/experimental/fixtures because it exists
+    # only to give a records fixture an event; the impl header is the shared one.
+    cat > d_metadata.json <<'EOF'
+    {
+      "name": "records_events_mod",
+      "version": "1.0.0",
+      "type": "core",
+      "dependencies": [],
+      "events": [
+        { "name": "blobStored", "params": [ { "name": "id", "type": "std::string" } ] }
+      ]
+    }
+    EOF
+    logos-cpp-generator --from-header "$fixtures/records_impl.h" \
+      --impl-class RecordsImpl --metadata ./d_metadata.json \
+      --backend cdylib --output-dir ./D >/dev/null \
+      || fail "D: the records+events fixture was refused"
+    assert_config "D: records + events" ./D
+
+    mkdir -p "$out"
+    echo "the cdylib backend defines every module-impl export logos-protocol $(cat ${module-impl-abi}/version) declares" \
+      > "$out/result.txt"
+  ''


### PR DESCRIPTION
Stacked on **[logos-protocol#66](https://github.com/logos-co/logos-protocol/pull/66)** — do not merge before it, or master pins an unmerged commit.

## Why

logos-protocol *declares* the module-impl C ABI; this generator *emits* the definitions. Independent facts, and the gap has shipped twice — `grant_host_services` at 0.3, the teardown pair at 0.5 — each time as an `undefined symbol` at `dlopen`, on Linux only, with the runtime still reporting the module as LOADED.

`checks.<system>.module-impl-abi` generates in all four shapes the emitter can be reached in and diffs what each **defines** against the list logos-protocol publishes. Both the list and the protocol version come from that one output, so there is no version arithmetic here and nothing hardcoded.

## The part worth reviewing: why this isn't vacuous

The obvious implementation is. The generated `.cpp` carries the version guards as **text**, so a plain grep counts all ten exports at every protocol version and the check passes forever. `unifdef` resolves them — but `unifdef` given an expression it cannot evaluate **exits 0 and leaves the text alone**, which looks exactly like "nothing was conditional". Both traps were reproduced, not assumed. So:

- no residual `#if/#else/#endif` may survive the resolution;
- the same pipeline runs **twice**, at the real MINOR and at MINOR=0, and the MINOR=0 set must be a **strict subset**.

That second assertion is the headline guard. It fires if `unifdef` no-opped, if the version never reached it, or if the extraction were counting *mentions* rather than definitions — without naming a single symbol or version, so it doesn't go stale as the ABI grows.

```
  [A: --from-header, header-first] version probe: 7 exports at MINOR=0, 10 at MINOR=5
[A: --from-header, header-first] defines all 10 declared module-impl exports.
  [B: --lidl, contract-first] version probe: 7 exports at MINOR=0, 10 at MINOR=5
[B: --lidl, contract-first] defines all 10 declared module-impl exports.
  [C: zero-method module] ... 10 declared module-impl exports.
  [D: records + events] ... 10 declared module-impl exports.
```

## Proven to fail

Commenting out the `logos_module_string_free` emission → red, naming that symbol, while `tests` **and** `generator-cli` both stay **green**. This is the only thing in the repo that notices a deleted export.

Moving the teardown guard `>= 5` → `>= 6` → red naming both teardown symbols, with the probe moving 10 → 8. The version resolution is live, not a name list.

An adversarial audit independently re-ran both controls and attempted five vacuity attacks (empty extraction, short extraction, broken declared path, breaking only the *last* configuration, and swallowed exit codes). The check survived all of them; verdict **SOUND**. Three cosmetic defects it found are fixed here (a `nullglob`-dead guard, a `cat` that could block on stdin outside nix, and two failure sites that named the file rather than the configuration — A and B emit the same filename).

Verified on **x86_64-linux** as well as aarch64-darwin. That matters: an earlier revision of the shared helper resolved its interpreter via `env` and silently did not execute in the Linux sandbox.

## Also

`ci.yml` only ever built `.#tests` plus three binaries, so the `checks` attrset was **never evaluated** — `generator-cli` has never run in CI. Added a step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)