### PR TITLE
fix(abi-check): the next-major probe asserts a SUBSET, not equality

### DIFF
--- a/nix/tests-module-impl-abi.nix
+++ b/nix/tests-module-impl-abi.nix
@@ -167,7 +167,15 @@ pkgs.runCommand "${common.pname}-module-impl-abi-tests"
       # So: at one major up, the export set must be complete. This assertion
       # fails against a MINOR-only guard and passes against a MAJOR-aware one,
       # which is the whole reason it exists.
-      if ! cmp -s "$dir/at-nextmaj.txt" <(sort -u "$declared"); then
+      # SUBSET, not equality. The property is "everything DECLARED is still
+      # emitted once the major advances" — an emitter that defines MORE than the
+      # protocol currently declares is not a failure, it is how a backend lands
+      # a new export BEFORE the protocol bump that declares it reaches this
+      # repo's lock. Requiring equality forbids that ordering, and forbids it
+      # with an empty diff under a heading blaming MAJOR-awareness, because the
+      # message below already computes the subset direction. Guard and
+      # diagnostic have to agree or the failure teaches the wrong lesson.
+      if [ -n "$(comm -13 "$dir/at-nextmaj.txt" <(sort -u "$declared"))" ]; then
         {
           echo "FAIL: [$label] the export set is not complete at protocol $((major + 1)).0."
           echo


### PR DESCRIPTION
Small fix, but it unblocks the only safe PR order for the next protocol bump.

## The bug

The next-major probe exists to catch a version guard written on `LOGOS_PROTOCOL_VERSION_MINOR` alone: at the next major the MINOR resets to 0, the guard goes false, and the surface disappears **silently** — no link error, no `dlopen` failure, because the matching calls are guarded the same way and vanish with it.

That property is *"everything **declared** is still emitted at major+1"* — a **subset** test. It was written as `cmp -s`, an **equality** test, so it also fails when the emitter defines *more* than the protocol currently declares.

Worse, the diagnostic underneath already computes the subset direction with `comm -13`. So guard and message disagreed: the offending case failed with an **empty list of offenders** under a heading blaming MAJOR-awareness. A guard and its message have to agree, or the failure teaches the wrong lesson.

## Why it matters now

Defining an export *before* the protocol bump that declares it reaches this repo's lock is not a defect — it is the **only PR order that avoids a window where every backend is red through no fault of its own**.

The next protocol bump (0.5 → 0.6, adding `logos_module_set_call_caller` for caller context) needs exactly that. With equality, protocol-first is forced, and the night PR1 merges the workspace nightly turns cpp-sdk, rust-sdk *and* module-builder red and stalls the bump pipeline until the backend PRs land. With the subset test, backends can land their definitions first and nothing is ever red.

## Verified on Linux, three cases from a clean tree

| case | expected | result |
|---|---|---|
| unmodified, protocol 0.5 | PASS (no-op) | **PASS** |
| `logos_module_string_free` emission removed | RED, naming it | **RED**, `- logos_module_string_free` |
| an *undeclared* export emitted | PASS (superset allowed) | **PASS** |

Case 2 confirms the probe still does its actual job; case 3 is the new capability.

Run on x86_64-linux deliberately — an undefined symbol is invisible on macOS, which is how this class of bug reached production twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)