### PR TITLE
fix: bound the argument count above; and an lp reply it cannot read

### DIFF
--- a/cpp-generator/experimental/lidl_gen_cdylib.cpp
+++ b/cpp-generator/experimental/lidl_gen_cdylib.cpp
@@ -820,6 +820,31 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
             s << "                return lidlStrdup(err.dump());\n";
             s << "            }\n";
         }
+        // ...and so is a wrong count in the OTHER direction, which nothing
+        // checked until now: an EXTRA argument was silently dropped and the
+        // call succeeded. `args.size() < minArgs` bounds one side only.
+        //
+        // Arity is the one part of a contract a caller cannot verify for
+        // itself. A method that gains or loses a parameter upstream answered a
+        // stale caller with a plausible value instead of a refusal, and the
+        // caller had no way to tell which contract it had just talked to.
+        //
+        // Emitted UNCONDITIONALLY, including for a zero-parameter method
+        // (`args.size() > 0`). That case is not the lower bound with maxArgs=0
+        // — it is the arm that had no gate at all, and it is the arm the
+        // derived identity methods take: `version("junk")` answered "1.0.0"
+        // with status ok, a correct-looking answer to a call that should have
+        // been refused. This sits ABOVE the `md.derived` branch below so the
+        // generated identity dispatch inherits it rather than needing its own.
+        const size_t maxArgs = md.params.size();
+        s << "            if (args.size() > " << maxArgs << ") {\n";
+        s << "                nlohmann::json err{{\"code\", \"invalid_args\"},\n";
+        s << "                                   {\"message\", \"expected "
+          << (minArgs == maxArgs ? "" : "at most ") << maxArgs
+          << " arguments, got \" + std::to_string(args.size())},\n";
+        s << "                                   {\"origin\", \"" << module.name << "\"}};\n";
+        s << "                return lidlStrdup(err.dump());\n";
+        s << "            }\n";
         // A derived method (lidl/identity.hpp) has no member on the impl class
         // to call — the generator owns its body. name()/version() answer from
         // the module declaration, which the builder derives from metadata.json,

--- a/cpp/logos_lp_client.h
+++ b/cpp/logos_lp_client.h
@@ -57,13 +57,33 @@ inline std::vector<uint8_t> jsonToBytes(const nlohmann::json& j) {
     return b64UrlDecode(j["_bytes"].get<std::string>());
 }
 
+// A reply that is NOT a result object is a decode failure, and must not be
+// spelled as a default-constructed StdLogosResult.
+//
+// Every other lenient decode in this file bottoms out at a value no provider
+// means as an answer -- "" for a string, 0 for a number, {} for a map. This one
+// does not: `success = false` with an empty error is exactly what a provider
+// sends when it REFUSES a call, so returning the default made "I could not read
+// this reply" indistinguishable from "you were rejected". Measured on the Qt
+// twin of this function (logos::jsonToLogosResult, same shape, same opening
+// `if (!is_object)`), where a wrapper bound to a provider with a different
+// return shape answered a refusal to every input including the well-formed
+// ones.
+//
+// The leniency of the BARE SCALARS above is untouched and deliberate --
+// logos-qt-sdk's tests/qt-generator bare_scalar_slots_stay_lenient pins it on
+// the other surface, and tightening that is a decision about every scalar
+// return of every module. This is the one type whose default is a message.
 inline StdLogosResult jsonToStdResult(const nlohmann::json& j) {
     StdLogosResult r;
-    if (j.is_object()) {
-        if (j.contains("success") && j["success"].is_boolean()) r.success = j["success"].get<bool>();
-        if (j.contains("value"))                                r.value = j["value"];
-        if (j.contains("error") && j["error"].is_string())      r.error = j["error"].get<std::string>();
+    if (!j.is_object()) {
+        r.success = false;
+        r.error = std::string("expected a result object, got ") + j.type_name();
+        return r;
     }
+    if (j.contains("success") && j["success"].is_boolean()) r.success = j["success"].get<bool>();
+    if (j.contains("value"))                                r.value = j["value"];
+    if (j.contains("error") && j["error"].is_string())      r.error = j["error"].get<std::string>();
     return r;
 }
 

--- a/tests/experimental/test_lidl_gen_cdylib.cpp
+++ b/tests/experimental/test_lidl_gen_cdylib.cpp
@@ -531,12 +531,37 @@ TEST(LidlGenCdylib, WrongArgumentCountReportsInvalidArgs)
     EXPECT_TRUE(src.contains("return lidlStrdup(err.dump());")) << src.toStdString();
     // The silent reply is gone from the arity path.
     EXPECT_FALSE(src.contains("if (args.size() < 2) return nullptr;")) << src.toStdString();
-    EXPECT_FALSE(src.contains("args.size() > ")) << src.toStdString();
+    // ...and the count is bounded on BOTH sides. An extra argument used to be
+    // dropped and the call to succeed. With no optional parameters the two
+    // bounds coincide, so the message stays the plain "expected 2".
+    EXPECT_TRUE(src.contains("if (args.size() > 2) {")) << src.toStdString();
+    EXPECT_FALSE(src.contains("expected at most 2 arguments")) << src.toStdString();
+}
+
+// A trailing optional makes the accepted arity a RANGE, and the upper bound is
+// the declared parameter count, not the required one — otherwise supplying the
+// optional would be rejected as an overflow.
+TEST(LidlGenCdylib, OptionalArgumentWidensTheUpperBound)
+{
+    ModuleDecl m;
+    m.name = "o_module";
+    m.methods.push_back(method("f", prim("tstr"),
+                               {param("required", prim("tstr")),
+                                param("maybe", opt(prim("tstr")))}));
+
+    const QString src = lidlMakeModuleImplExports(m, "OImpl", "o_impl.h");
+    EXPECT_TRUE(src.contains("if (args.size() < 1) {")) << src.toStdString();
+    EXPECT_TRUE(src.contains("if (args.size() > 2) {")) << src.toStdString();
+    // The two bounds differ, so the message says so rather than claiming an
+    // exact count the method does not require.
+    EXPECT_TRUE(src.contains("\"expected at most 2 arguments, got \"")) << src.toStdString();
 }
 
 // `args.size()` is unsigned, so `< 0` never fires: a zero-argument method
-// carried a dead branch. The Rust generator has always skipped it; now both do.
-TEST(LidlGenCdylib, ZeroArgumentMethodEmitsNoArityGate)
+// carries no LOWER gate. It does carry an upper one. This test used to assert
+// the arm emitted no `invalid_args` at all, which is precisely the defect --
+// `ping("junk")` dropped the argument and answered normally.
+TEST(LidlGenCdylib, ZeroArgumentMethodStillRejectsExtraArguments)
 {
     ModuleDecl m;
     m.name = "o_module";
@@ -544,8 +569,29 @@ TEST(LidlGenCdylib, ZeroArgumentMethodEmitsNoArityGate)
 
     const QString src = lidlMakeModuleImplExports(m, "OImpl", "o_impl.h");
     EXPECT_FALSE(src.contains("args.size() < 0")) << src.toStdString();
-    EXPECT_FALSE(src.contains("invalid_args")) << src.toStdString();
+    EXPECT_TRUE(src.contains("if (args.size() > 0) {")) << src.toStdString();
+    EXPECT_TRUE(src.contains("{\"code\", \"invalid_args\"}")) << src.toStdString();
     EXPECT_TRUE(src.contains("lidlImpl().ping()")) << src.toStdString();
+}
+
+// The generated identity dispatch (name/version) is answered by the generator
+// itself and returns BEFORE any impl call, so it needs the bound to sit above
+// the `derived` branch. `version("junk")` answering "1.0.0" with status ok was
+// worse than answering nothing: a correct-looking reply to a refused call.
+TEST(LidlGenCdylib, DerivedIdentityMethodRejectsExtraArguments)
+{
+    ModuleDecl m;
+    m.name = "o_module";
+    m.version = "2.3.4";
+    MethodDecl v = method("version", prim("tstr"), {});
+    v.derived = true;
+    m.methods.push_back(v);
+
+    const QString src = lidlMakeModuleImplExports(m, "OImpl", "o_impl.h");
+    EXPECT_TRUE(src.contains("if (args.size() > 0) {")) << src.toStdString();
+    EXPECT_TRUE(src.contains("{\"code\", \"invalid_args\"}")) << src.toStdString();
+    // The literal is still answered for a well-formed call.
+    EXPECT_TRUE(src.contains("std::string(\"2.3.4\")")) << src.toStdString();
 }
 
 // R4. Optional widens the accepted domain by exactly ONE inhabitant (empty); a


### PR DESCRIPTION
An EXTRA argument was silently dropped and the call succeeded — on both providers, in both language backends, across two different contracts, at every arity including zero. Registered in the conformance matrix as `B-arity-overflow` and `B-arity-overflow-identity`, 36 cells.

## Why this one matters more than it reads

Arity is the one part of a contract a caller cannot verify for itself. A method that gains or loses a parameter upstream answered a stale caller with a **plausible value instead of a refusal**, and the caller had no way to tell which contract it had just talked to.

The identity case is the sharp end: `version("junk")` answered `"1.0.0"` with status ok. That is worse than answering nothing — it is a correct-looking reply to a call that should have been refused.

## Three arms, not one

The conformance table registered these as two defects and three cases, and that decomposition was right — each is a separate emitter path:

1. **The ordinary arm** gets `args.size() > maxArgs`, bounded by the **declared** parameter count rather than the required one. Bounding at `minArgs` would reject a caller who legitimately supplies a trailing optional.
2. **A zero-parameter method had no gate at all.** Not the same guard with `minArgs = 0` — `args.size() < 0` is unsigned and was skipped as dead, so the arm emitted nothing. The upper bound is emitted unconditionally.
3. **The identity arm.** In C++ it sits below the guard and inherits it. In Rust it `continue`s before the ordinary dispatch is emitted and inherits nothing, so it gets its own `!args.is_empty()` check.

When the two bounds coincide the message keeps the exact-count wording; when they differ it says `at most`, because claiming a count the method does not require would be wrong in the other direction. `invalid_args_max` is added beside `invalid_args` in rust-sdk for that, and the C++ glue chooses between the same two spellings on the same condition — preserving the cross-backend parity `invalid_args_shape_matches_cpp` claims.

## Tests that asserted the defect

Two existing tests encoded the old behaviour as a guarantee and are corrected, not deleted:

- `ZeroArgumentMethodEmitsNoArityGate` asserted a zero-arg method emitted **no `invalid_args` at all**. That assertion *was* the defect, written down.
- `provider_speaks_optionals` (Rust) pinned an all-optional method's binding as adjacent to its arm opening, to show it "demands nothing". That conflated **demands nothing** with **accepts anything**. The first still holds; the second is what closes here.

Added: a trailing optional widening the upper bound, and the derived identity dispatch, on both backends.

## Verification

`nix build .#checks.x86_64-linux.*` on all exposed checks, on a 24-core Linux box:

```
logos-cpp-sdk    generator-cli PASS   module-impl-abi PASS   tests PASS
logos-rust-sdk   ipc-test PASS        module-impl-abi PASS   sdk-unit-tests PASS
```



---

# Second, independent fix in this branch: `jsonToStdResult`

Two commits, two unrelated defects, kept together only because both are in this repo and the second is time-coupled to [qt-sdk#44](https://github.com/logos-co/logos-qt-sdk/pull/44). Review them separately; they touch different files.

`jsonToStdResult` returned a default-constructed `StdLogosResult` for any non-object reply, and that default — `success = false`, empty error — is byte-for-byte what a provider sends when it **refuses** a call. So "I could not read this reply" and "you were rejected" were the same value, and no lp caller could separate them.

Every other lenient decode in `logos_lp_client.h` bottoms out at a value no provider means as an answer: `""` for a string, `0` for a number, `{}` for a map. This one did not.

**Why it is in the same change as the Qt fix rather than after it:** logos-qt-sdk's `bare_scalar_slots_stay_lenient` explicitly warns that tightening a scalar decode on one consumer surface without the other makes the two diverge. It is right, and the lp surface has the identical function with the identical opening. The bare scalars stay lenient on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
