### PR TITLE
feat(cdylib): define logos_module_accept_inbound_token

### DIFF
--- a/cpp-generator/experimental/lidl_gen_cdylib.cpp
+++ b/cpp-generator/experimental/lidl_gen_cdylib.cpp
@@ -895,13 +895,57 @@ QString lidlMakeModuleImplExports(const ModuleDecl& module,
 
     s << "int logos_module_accept_token(const char* module_name, const char* token)\n{\n";
     s << "    if (!module_name || !token) return -1;\n";
-    s << "    // Seed the protocol's shared TokenManager so this module's OUTBOUND\n";
-    s << "    // lp_client (modules().<dep>...) can authenticate calls. In\n";
-    s << "    // particular the capability_module bootstrap token the host\n";
-    s << "    // delivers at load lets the automatic requestModule flow fetch a\n";
-    s << "    // per-target token on the first cross-module call. lp_token_save\n";
+    s << "    // THE OUTBOUND DOOR. Seed the protocol's shared TokenManager so this\n";
+    s << "    // module's OUTBOUND lp_client (modules().<dep>...) can authenticate\n";
+    s << "    // calls. In particular the capability_module bootstrap token the\n";
+    s << "    // host delivers at load lets the automatic requestModule flow fetch\n";
+    s << "    // a per-target token on the first cross-module call. lp_token_save\n";
     s << "    // writes the same TokenManager::instance() the lp_client reads.\n";
+    s << "    //\n";
+    s << "    // ONE MEANING ONLY, as of protocol 0.8. The Qt glue used to call\n";
+    s << "    // this from onInit (the module's own anchor -- outbound, correct)\n";
+    s << "    // AND from informModuleToken (a CALLER's token -- inbound, filed\n";
+    s << "    // here as an outbound credential). The caller path now goes through\n";
+    s << "    // logos_module_accept_inbound_token below. Do not merge them.\n";
     s << "    return lp_token_save(module_name, token);\n}\n\n";
+
+    // THE INBOUND DOOR (protocol 0.8). logos-protocol only DECLARES it; this
+    // backend owes the definition, and so does logos-rust-sdk, IN THE SAME
+    // WAVE. A module generated for >= 0.8 whose backend omits this links
+    // cleanly and then fails at dlopen() on ELF with "undefined symbol" --
+    // invisible on macOS, which links plugins -undefined dynamic_lookup. That
+    // has now shipped three times (grant_host_services at 0.3, the teardown
+    // pair at 0.5, set_call_caller at 0.6), every time at perfect version
+    // agreement, because agreeing on the VERSION says nothing about which
+    // SYMBOLS a backend's emitter writes. checks.module-impl-abi is what makes
+    // it fail here instead of at a user's dlopen.
+    //
+    // Guarded MAJOR-aware, not on the MINOR alone, for the reason spelled out
+    // at set_call_caller below: at 1.0 the MINOR resets to 0, a `MINOR >= 8`
+    // guard goes false, and the definition disappears together with the glue's
+    // call -- so nothing fails to build, nothing fails to load, and every
+    // module silently goes back to filing its callers as outbound credentials.
+    // Written expanded because unifdef must be able to evaluate it.
+    s << "#if defined(LOGOS_PROTOCOL_VERSION_MINOR) && "
+         "(LOGOS_PROTOCOL_VERSION_MAJOR > 0 || "
+         "(LOGOS_PROTOCOL_VERSION_MAJOR == 0 && "
+         "LOGOS_PROTOCOL_VERSION_MINOR >= 8))\n";
+    s << "int logos_module_accept_inbound_token(const char* caller, const char* token)\n{\n";
+    s << "    if (!caller || !token) return -1;\n";
+    s << "    // THE INBOUND DOOR: `caller` is the module that will CALL US and\n";
+    s << "    // `token` is what it will present. This is NOT a credential this\n";
+    s << "    // module may present to anyone, and lp_token_save_inbound writes a\n";
+    s << "    // key namespace lp_token_get and lp_token_keys cannot read -- which\n";
+    s << "    // is what stops a grant one way from being a grant the other way.\n";
+    s << "    //\n";
+    s << "    // One line, deliberately: the token-registry carve-out (a granted\n";
+    s << "    // registry ALSO gets the outbound entry, because for it the same\n";
+    s << "    // wire message means \"here is X's token, present it when you call\n";
+    s << "    // X\") lives in logos-protocol, where a unit test reaches it by\n";
+    s << "    // value. Logic that lives in emitted text is logic no test ever\n";
+    s << "    // executes, only greps.\n";
+    s << "    return lp_token_save_inbound(caller, token);\n}\n";
+    s << "#endif\n\n";
 
     // Guarded on the protocol MINOR that introduced the trust-root surface
     // (0.3). The emitted module must still COMPILE against an older

--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {

--- a/nix/tests-module-impl-abi.nix
+++ b/nix/tests-module-impl-abi.nix
@@ -111,6 +111,30 @@ pkgs.runCommand "${common.pname}-module-impl-abi-tests"
       set -o pipefail
     }
 
+    # ── WHICH DECLARED EXPORTS ARE LOST WHEN THE MAJOR ADVANCES ──────────────
+    #
+    # Declared, ABSENT at one major up, and PRESENT at the current protocol.
+    # All three conjuncts matter; the third is the one that was missing.
+    #
+    # "Declared minus at-nextmaj" alone also contains every export the backend
+    # does not define AT ALL, and for those the MAJOR message below is simply
+    # false — there is no MINOR-only guard to make MAJOR-aware, and it sends the
+    # reader to expand arithmetic in code that does not exist. That failure has
+    # its own check, logos-module-impl-diff, which names it correctly; it just
+    # never got to run, because this probe fired first and exited.
+    #
+    # Intersecting with at-$minor is what splits the two: a symbol defined now
+    # and gone at the next major is a version-guard bug and lands here; a symbol
+    # defined at neither is not this probe's business and falls through to the
+    # diff. Both faults are still caught in one run — see the self-test after
+    # `cd work`, which exercises this routing on synthetic sets.
+    #
+    # Pure: reads three sorted files, prints a set, decides nothing. Factored
+    # out of assert_config so it can be self-tested at all.
+    major_only_losses() {   # <at-nextmaj.txt> <at-minor.txt> <declared.txt>
+      comm -12 <(comm -13 "$1" <(sort -u "$3")) <(sort -u "$2")
+    }
+
     assert_config() {   # <label> <generated-dir>
       label="$1"; dir="$2"; cfg_label="$label"
       # nixpkgs builders run with `shopt -s nullglob`, so a non-matching
@@ -175,12 +199,18 @@ pkgs.runCommand "${common.pname}-module-impl-abi-tests"
       # with an empty diff under a heading blaming MAJOR-awareness, because the
       # message below already computes the subset direction. Guard and
       # diagnostic have to agree or the failure teaches the wrong lesson.
-      if [ -n "$(comm -13 "$dir/at-nextmaj.txt" <(sort -u "$declared"))" ]; then
+      #
+      # AND NOT EVERY MISSING EXPORT IS THIS FAULT. One defined at NO version is
+      # not a version guard at all; major_only_losses leaves it out, and
+      # logos-module-impl-diff at the end of this function names it correctly.
+      # Same run, right lesson each — see the selector's own note.
+      lost=$(major_only_losses "$dir/at-nextmaj.txt" "$dir/at-$minor.txt" "$declared")
+      if [ -n "$lost" ]; then
         {
           echo "FAIL: [$label] the export set is not complete at protocol $((major + 1)).0."
           echo
           echo "  DECLARED but NOT emitted once the MAJOR advances:"
-          comm -13 "$dir/at-nextmaj.txt" <(sort -u "$declared") | sed 's/^/      - /'
+          printf '%s\n' "$lost" | sed 's/^/      - /'
           echo
           echo "  This is a version guard testing LOGOS_PROTOCOL_VERSION_MINOR without"
           echo "  LOGOS_PROTOCOL_VERSION_MAJOR. At $((major + 1)).0 the MINOR is 0, so the"
@@ -222,6 +252,63 @@ pkgs.runCommand "${common.pname}-module-impl-abi-tests"
     }
 
     mkdir -p work && cd work
+
+    # ── SELF-TEST OF THE TWO DIAGNOSTICS ─────────────────────────────────────
+    #
+    # There are two ways an export can be missing from the at-nextmaj set and
+    # they are DIFFERENT FAULTS with different fixes:
+    #
+    #   * guarded on MINOR without MAJOR — defined at the current protocol,
+    #     gone at the next major. The message above is right, and the fix is to
+    #     expand the arithmetic in the emitter.
+    #   * not defined AT ALL — absent at every version. The message above is
+    #     WRONG: there is no guard to make MAJOR-aware, and a reader sent to
+    #     "expand the arithmetic" is sent to code that does not exist.
+    #     logos-module-impl-diff is the check that owns this failure and it says
+    #     so in those words.
+    #
+    # The MAJOR probe used to run FIRST and to select on "declared minus
+    # at-nextmaj", which contains both. An entirely absent definition was
+    # therefore reported as a version-guard bug and the diff that would have
+    # named it correctly never ran. Gating the selector on presence at
+    # at-$minor is what routes each fault to its own diagnostic — and since
+    # both are inline shell, this exercises the routing on synthetic sets
+    # rather than on whatever the generator happens to emit today.
+    mkdir -p st
+    printf 'logos_module_a\nlogos_module_b\n'                  > st/declared
+    printf 'logos_module_a\n'                                   > st/absent-minor
+    printf 'logos_module_a\n'                                   > st/absent-nextmaj
+    printf 'logos_module_a\nlogos_module_b\n'                  > st/guarded-minor
+    printf 'logos_module_a\n'                                   > st/guarded-nextmaj
+    printf 'logos_module_a\nlogos_module_b\nlogos_module_c\n' > st/healthy-minor
+    printf 'logos_module_a\nlogos_module_b\nlogos_module_c\n' > st/healthy-nextmaj
+
+    st_expect() {   # <case> <expected-set-or-empty> <nextmaj> <minor>
+      got=$(major_only_losses "$3" "$4" st/declared)
+      [ "$got" = "$2" ] || fail \
+        "self-test [$1]: the MAJOR probe selected '$got', expected '$2'"
+    }
+
+    # (a) b is declared and defined NOWHERE. The MAJOR probe must stay silent
+    #     and leave the failure to logos-module-impl-diff.
+    st_expect absent "" st/absent-nextmaj st/absent-minor
+    if logos-module-impl-diff st/declared st/absent-minor "self-test" >/dev/null 2>&1; then
+      fail "self-test [absent]: logos-module-impl-diff accepted a missing export"
+    fi
+
+    # (b) b IS defined now and vanishes at the next major: a MINOR-only guard,
+    #     which is exactly what the MAJOR probe exists to name.
+    st_expect guarded "logos_module_b" st/guarded-nextmaj st/guarded-minor
+    logos-module-impl-diff st/declared st/guarded-minor "self-test" >/dev/null \
+      || fail "self-test [guarded]: the current-protocol diff should have been happy"
+
+    # (c) nothing wrong, and the emitter defines MORE than the protocol
+    #     declares — the ordering that lands a new export before the bump that
+    #     declares it. Neither diagnostic may fire.
+    st_expect healthy "" st/healthy-nextmaj st/healthy-minor
+    logos-module-impl-diff st/declared st/healthy-minor "self-test" >/dev/null \
+      || fail "self-test [healthy]: a superset of the declared list must pass"
+    echo "  [self-test] the two diagnostics route their own faults"
 
     # ── A. Header-first ──────────────────────────────────────────────────────
     logos-cpp-generator --from-header "$fixtures/universal_impl.h" \


### PR DESCRIPTION
## The definition

logos-protocol only **declares** the module-impl C ABI; every language backend owes each
definition. A missing one links clean and dies at `dlopen` — **on Linux only**, because macOS
links plugins `-undefined dynamic_lookup` and hides it entirely. This has shipped three times.

Adds `logos_module_accept_inbound_token` (protocol 0.8), gated on expanded MAJOR-aware arithmetic
so it stays inert until a lock carries 0.8 and does not silently stop emitting at 1.0.0.

## A misrouted diagnostic, fixed

`nix/tests-module-impl-abi.nix` ran the `at-nextmaj` MAJOR probe *before* the export diff, so an
export that **nothing** defines was reported as:

```
"This is a version guard testing LOGOS_PROTOCOL_VERSION_MINOR without LOGOS_PROTOCOL_VERSION_MAJOR..."
```

— the wrong lesson, sending the reader to fix a guard that isn't there. Reproduced on a planted
fault (`logos_module_never_defined`), and after the fix:

```
FAIL: does not define every module-impl C ABI export.
  DECLARED by logos-protocol but NOT DEFINED by this backend:
      - logos_module_never_defined
  Add the definition here: cpp-generator/experimental/lidl_gen_cdylib.cpp
```

The probe is now gated on the symbol being present at the current MINOR. Because both diagnostics
are inline shell and otherwise untestable, there is a **self-test** over synthetic sets
(absent-everywhere / MINOR-only-guard / healthy-superset) — red first with the un-gated formula:

```
FAIL: self-test [absent]: the MAJOR probe selected 'logos_module_b', expected ''
```

Anti-vacuity: neutering a real guard to MINOR-only still fires the MAJOR probe correctly.

## Verified

Removing the emitter block turns `checks.<sys>.module-impl-abi` **red naming the symbol**, in the
check rather than at compile time.

## Requires

logos-protocol#73 (`fix/token-direction-key-namespace`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
